### PR TITLE
Events can occur without ocurrence data

### DIFF
--- a/src/main/java/org/gbif/ipt/task/GenerateDwca.java
+++ b/src/main/java/org/gbif/ipt/task/GenerateDwca.java
@@ -755,11 +755,7 @@ public class GenerateDwca extends ReportingTask implements Callable<Integer> {
     boolean validEventCore = true;
     // test if occurrence extension mapped
     ArchiveFile occurrenceExtension = arch.getExtension(DwcTerm.Occurrence);
-    if (occurrenceExtension == null) {
-      validEventCore = false;
-    }
-    // test if it has at least one record
-    else {
+    if (occurrenceExtension != null) {
       if (!occurrenceExtension.iterator().hasNext()) {
         validEventCore = false;
       }


### PR DESCRIPTION
Many times ecologists or other disciplines will try to sample abiotic data without any species information. Like air CO2/temperature or they have sampled them in distinct times.

So validateEventCore will only try to validate the archive if occurrence extension is sets. Making event core more flexible.