### PR TITLE
Use the DefaultHttpClient created by Guice when creating an HttpUtil

### DIFF
--- a/src/main/java/org/gbif/ipt/config/IPTModule.java
+++ b/src/main/java/org/gbif/ipt/config/IPTModule.java
@@ -122,9 +122,7 @@ public class IPTModule extends AbstractModule {
 
   @Provides
   @Inject
-  public HttpUtil provideHttpUtil() {
-    // Retrieve the same client instance as configured in this module
-    DefaultHttpClient client = provideHttpClient();
+  public HttpUtil provideHttpUtil(DefaultHttpClient client) {
     // Return a singleton instance of HttpUtil
     return new HttpUtil(client);
   }


### PR DESCRIPTION
Hello,

About three weeks ago we got new instances of IPT running in our productions servers. These servers are not behind a proxy, but some years ago we had problems with our proxy and IPT (see [1] or [2]).

Our development machines are behind the same proxy that caused the old issues. We needed to debug IPT to solve duplicate entries when importing data, and found that it wasn't easy due to the proxy problems.

After debugging a little bit the code, we could see that even though the Action was correctly saving the proxy into the client, later the Vocabulary Manager would use another client without the proxy. Looking at IPTModule Guice module, the HttpUtil was calling the method `provideHttpClient` directly. This leads to Guice calling the provideHttpClient only (Singleton), but the HttpUtil method provided by Guice would use a different DefaultHttpClient.

Fixed and tested locally behind our proxy.

Hope that helps,
Bruno

[1] https://code.google.com/p/gbif-providertoolkit/issues/detail?id=931
[2] https://github.com/gbif/ipt/issues/931