### PR TITLE
Add title to DwC-A distribution

### DIFF
--- a/src/main/java/org/gbif/ipt/task/GenerateDCAT.java
+++ b/src/main/java/org/gbif/ipt/task/GenerateDCAT.java
@@ -683,6 +683,12 @@ public class GenerateDCAT {
     distributionBuilder.append("\n");
     distributionBuilder.append("a dcat:Distribution");
 
+    //dct:title
+    if (eml.getTitle() != null) {
+      addPredicateToBuilder(distributionBuilder, "dct:title");
+      addObjectToBuilder(distributionBuilder, "Darwin Core Archive of " + eml.getTitle(), ObjectTypes.LITERAL);
+    }
+    
     //dct:description
     addPredicateToBuilder(distributionBuilder, "dct:description");
     addObjectToBuilder(distributionBuilder, "Darwin Core Archive", ObjectTypes.LITERAL);


### PR DESCRIPTION
To be compliant with the best practices of DCAT, a distribution of a dataset should also have I title. I opted for "Darwin Core Archive of `title of dataset`". I made an attempt here to include the necessary code in the DCAT feed generator, but this has **not been tested**.