### PR TITLE
fix #1449 do not call ActionSupport#getLocal() method on none action context.

### DIFF
--- a/src/main/java/org/gbif/ipt/action/BaseAction.java
+++ b/src/main/java/org/gbif/ipt/action/BaseAction.java
@@ -2,6 +2,7 @@ package org.gbif.ipt.action;
 
 import com.google.common.base.Strings;
 import com.google.inject.Inject;
+import com.opensymphony.xwork2.ActionContext;
 import com.opensymphony.xwork2.ActionSupport;
 import com.opensymphony.xwork2.Preparable;
 import com.opensymphony.xwork2.util.ValueStack;
@@ -166,13 +167,23 @@ public class BaseAction extends ActionSupport implements SessionAware, Preparabl
     return Locale.ENGLISH.getLanguage();
   }
 
+  /**
+   * Gets the provided locale. in ActionContext.
+   *
+   * fix #1449 NPE on none struts context.
+   */
+  @Override
+  public Locale getLocale() {
+      return (ActionContext.getContext() != null) ? super.getLocale() : null;
+  }
+
   @Override
   public String getText(String key) {
     return textProvider.getText(this, key, null, new String[0]);
   }
 
   @Override
-  public String getText(String key, List args) {
+  public String getText(String key, List<?> args) {
     return textProvider.getText(this, key, null, args);
   }
 
@@ -182,12 +193,12 @@ public class BaseAction extends ActionSupport implements SessionAware, Preparabl
   }
 
   @Override
-  public String getText(String key, String defaultValue, List args) {
+  public String getText(String key, String defaultValue, List<?> args) {
     return textProvider.getText(this, key, defaultValue, args);
   }
 
   @Override
-  public String getText(String key, String defaultValue, List args, ValueStack stack) {
+  public String getText(String key, String defaultValue, List<?> args, ValueStack stack) {
     return textProvider.getText(this, key, defaultValue, args);
   }
 

--- a/src/test/java/org/gbif/ipt/action/BaseActionTest.java
+++ b/src/test/java/org/gbif/ipt/action/BaseActionTest.java
@@ -1,0 +1,56 @@
+package org.gbif.ipt.action;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+import java.util.Locale;
+
+import org.gbif.ipt.config.AppConfig;
+import org.gbif.ipt.service.admin.RegistrationManager;
+import org.gbif.ipt.struts2.SimpleTextProvider;
+import org.junit.Test;
+
+import com.opensymphony.xwork2.ActionContext;
+import com.opensymphony.xwork2.LocaleProvider;
+import com.opensymphony.xwork2.LocaleProviderFactory;
+import com.opensymphony.xwork2.inject.Container;
+
+public class BaseActionTest {
+
+    /**
+     * Test getLocale on none Struts action context.
+     */
+    @Test
+    public void testGetLocaleOnNoneActionContext() {
+        BaseAction action = new BaseAction(mock(SimpleTextProvider.class), mock(AppConfig.class), mock(RegistrationManager.class));
+        assertEquals(null, action.getLocale());
+    }
+
+    /**
+     * Test getLocale on Struts action context.
+     */
+    @Test
+    public void testGetLocaleOnActionContext() {
+
+        //Simple mocked ActionContext
+        ActionContext mockActionContext = mock(ActionContext.class);
+        Container mockContainer = mock(Container.class);
+        LocaleProviderFactory mockLocaleProviderFactory = mock(LocaleProviderFactory.class);
+        LocaleProvider mockLocaleProvider = mock(LocaleProvider.class);
+
+        when(mockLocaleProvider.getLocale()).thenReturn(Locale.JAPANESE);
+        when(mockLocaleProviderFactory.createLocaleProvider()).thenReturn(mockLocaleProvider);
+        when(mockContainer.getInstance(LocaleProviderFactory.class)).thenReturn(mockLocaleProviderFactory);
+        when(mockActionContext.getContainer()).thenReturn(mockContainer);
+
+        //Set threadLocal ActionContext
+        ActionContext.setContext(mockActionContext);
+
+        //TEST
+        BaseAction action = new BaseAction(mock(SimpleTextProvider.class), mock(AppConfig.class), mock(RegistrationManager.class));
+        assertEquals(Locale.JAPANESE, action.getLocale());
+    }
+
+
+
+}


### PR DESCRIPTION
On Struts 2.5.14 (and later), ActionSupport#getLocal() throws NullPointerException on none action context thread. BaseAction class handle getLocal call and check it.

And small fixes generics warnings of List class.