### PR TITLE
Update vocabularies.xml

### DIFF
--- a/src/test/resources/vocabularies/vocabularies.xml
+++ b/src/test/resources/vocabularies/vocabularies.xml
@@ -1,6 +1,6 @@
 <map>
   <entry>
     <string>http://rs.gbif.org/vocabulary/gbif/datasettype</string>
-    <uri>http://rs.gbif.org/vocabulary/gbif/dataset_type.xml</uri>
+    <uri>http://rs.gbif.org/vocabulary/gbif/dataset_type_2015-07-10.xml</uri>
   </entry>
 </map>


### PR DESCRIPTION
The current version of dataset_type.xml is older than dataset_type_2015-07-10.xml, so it doesn't have samplingEvent which was added to
http://rs.gbif.org/vocabulary/gbif/dataset_type_2015-07-10.xml
I don't know why, but either the link should be changed here, or dataset_type.xml be updated.

Cheers,
Menashè