### PR TITLE
1506 Add options in auto-publish to define the next published date mo…

### DIFF
--- a/src/main/java/org/gbif/ipt/action/manage/AutoPublishAction.java
+++ b/src/main/java/org/gbif/ipt/action/manage/AutoPublishAction.java
@@ -1,0 +1,191 @@
+package org.gbif.ipt.action.manage;
+
+import com.google.inject.Inject;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.gbif.ipt.config.AppConfig;
+import org.gbif.ipt.config.Constants;
+import org.gbif.ipt.model.BiMonthEnum;
+import org.gbif.ipt.model.DayEnum;
+import org.gbif.ipt.model.MonthEnum;
+import org.gbif.ipt.model.voc.PublicationMode;
+import org.gbif.ipt.service.admin.RegistrationManager;
+import org.gbif.ipt.service.admin.VocabulariesManager;
+import org.gbif.ipt.service.manage.ResourceManager;
+import org.gbif.ipt.struts2.SimpleTextProvider;
+import org.gbif.ipt.utils.MapUtils;
+import org.gbif.metadata.eml.MaintenanceUpdateFrequency;
+
+import java.io.IOException;
+import java.util.*;
+
+public class AutoPublishAction extends ManagerBaseAction {
+
+    // logging
+    private static final Logger LOG = LogManager.getLogger(AutoPublishAction.class);
+
+    private static String OFF_FREQUENCY = "off";
+
+    private final VocabulariesManager vocabManager;
+
+    private Map<String, String> frequencies;
+    private Map<String, String> months;
+    private Map<String, String> biMonths;
+    private Map<Integer, String> days;
+    private Map<String, String> daysOfWeek;
+    private Map<Integer, String> hours;
+    private Map<Integer, String> minutes;
+
+    @Inject
+    public AutoPublishAction(SimpleTextProvider textProvider, AppConfig cfg, RegistrationManager registrationManager, ResourceManager resourceManager,
+                             VocabulariesManager vocabManager) {
+        super(textProvider, cfg, registrationManager, resourceManager);
+        this.vocabManager = vocabManager;
+    }
+
+    @Override
+    public void prepare() {
+        super.prepare();
+        // populate frequencies map
+        populateFrequencies();
+        populateMonths();
+        populateBiMonths();
+        populateDays();
+        populateDaysOfWeek();
+        populateHours();
+        populateMinutes();
+    }
+
+    public String save() {
+        String updateFrequency = req.getParameter(Constants.REQ_PARAM_AUTO_PUBLISH_FREQUENCY);
+        String updateFrequencyMonth = req.getParameter(Constants.REQ_PARAM_AUTO_PUBLISH_FREQUENCY_MONTH);
+        String updateFrequencyBiMonth = req.getParameter(Constants.REQ_PARAM_AUTO_PUBLISH_FREQUENCY_BIMONTH);
+        int updateFrequencyDay = Integer.parseInt(req.getParameter(Constants.REQ_PARAM_AUTO_PUBLISH_FREQUENCY_DAY));
+        String updateFrequencyDayOfWeek = req.getParameter(Constants.REQ_PARAM_AUTO_PUBLISH_FREQUENCY_DAYOFWEEK);
+        int updateFrequencyHour = Integer.parseInt(req.getParameter(Constants.REQ_PARAM_AUTO_PUBLISH_FREQUENCY_HOUR));
+        int updateFrequencyMinute = Integer.parseInt(req.getParameter(Constants.REQ_PARAM_AUTO_PUBLISH_FREQUENCY_MINUTE));
+
+        if (OFF_FREQUENCY.equals(updateFrequency)) {
+            LOG.debug("Turning off auto-publishing for ["+resource.getShortname()+"]");
+            resource.setPublicationMode(PublicationMode.AUTO_PUBLISH_OFF);
+            resource.clearAutoPublishingFrequency();
+        }
+        else if (MaintenanceUpdateFrequency.findByIdentifier(updateFrequency) != null ) {
+            LOG.debug("Updating auto-publishing for ["+resource.getShortname()+"] to: "+updateFrequency);
+            resource.setPublicationMode(PublicationMode.AUTO_PUBLISH_ON);
+            resource.setAutoPublishingFrequency(
+                    updateFrequency,
+                    updateFrequencyMonth,
+                    updateFrequencyBiMonth,
+                    updateFrequencyDay,
+                    updateFrequencyDayOfWeek,
+                    updateFrequencyHour,
+                    updateFrequencyMinute);
+        }
+        else {
+            LOG.error("Cannot update auto-publishing setting for ["+resource.getShortname()+"]. Unkown frequency: "+updateFrequency);
+            return ERROR;
+        }
+
+        // update next published date
+        resourceManager.updatePublicationMode(resource);
+        LOG.debug("Next published date updated for resource ["+resource.getShortname()+"]");
+
+        // save entire resource config
+        saveResource();
+        LOG.debug("Resource ["+resource.getShortname()+"] saved with new auto-publishing setting");
+
+        return SUCCESS;
+    }
+
+    public String cancel() {
+        return SUCCESS;
+    }
+
+    public Map<String, String> getFrequencies() {
+        return frequencies;
+    }
+
+    public Map<String, String> getMonths() {
+        return months;
+    }
+
+    public Map<String, String> getBiMonths() {
+        return biMonths;
+    }
+
+    public Map<Integer, String> getDays() {
+        return days;
+    }
+
+    public Map<String, String> getDaysOfWeek() {
+        return daysOfWeek;
+    }
+
+    public Map<Integer, String> getHours() {
+        return hours;
+    }
+
+    public Map<Integer, String> getMinutes() {
+        return minutes;
+    }
+
+    /**
+     * Populate frequencies map, representing the publishing interval choices uses have when configuring
+     * auto-publishing. The frequencies list is derived from an XML vocabulary, and will contain values in the requested
+     * locale, defaulting to English.
+     */
+    private void populateFrequencies() {
+        frequencies = new LinkedHashMap<String, String>();
+        frequencies.put(OFF_FREQUENCY, getText("manage.autopublish.off"));
+
+        // update frequencies list, that qualify for auto-publishing
+        Map<String, String> filteredFrequencies =
+                vocabManager.getI18nVocab(Constants.VOCAB_URI_UPDATE_FREQUENCIES, getLocaleLanguage(), false);
+        MapUtils.removeNonMatchingKeys(filteredFrequencies, MaintenanceUpdateFrequency.NON_ZERO_DAYS_UPDATE_PERIODS);
+        frequencies.putAll(filteredFrequencies);
+    }
+
+    private void populateMonths() {
+        months = new LinkedHashMap<String, String>();
+        for (MonthEnum month : MonthEnum.values()) {
+            months.put(month.getIdentifier(), getText("manage.autopublish."+month.getIdentifier()));
+        }
+    }
+
+    private void populateBiMonths() {
+        biMonths = new LinkedHashMap<String, String>();
+        for (BiMonthEnum biMonth : BiMonthEnum.values()) {
+            biMonths.put(biMonth.getIdentifier(), getText("manage.autopublish."+biMonth.getIdentifier()));
+        }
+    }
+
+    private void populateDays() {
+        days = new LinkedHashMap<Integer, String>();
+        for (int i=1; i<=31; i++) {
+            days.put(i, ((i<10) ? "0" : "") + String.valueOf(i));
+        }
+    }
+
+    private void populateDaysOfWeek() {
+        daysOfWeek = new LinkedHashMap<String, String>();
+        for (DayEnum dayOfWeek : DayEnum.values()) {
+            daysOfWeek.put(dayOfWeek.getIdentifier(), getText("manage.autopublish."+dayOfWeek.getIdentifier()));
+        }
+    }
+
+    private void populateHours() {
+        hours = new LinkedHashMap<Integer, String>();
+        for (int i=0; i<=23; i++) {
+            hours.put(i, ((i<10) ? "0" : "") + String.valueOf(i));
+        }
+    }
+
+    private void populateMinutes() {
+        minutes = new LinkedHashMap<Integer, String>();
+        for (int i=0; i<=59; i++) {
+            minutes.put(i, ((i<10) ? "0" : "") + String.valueOf(i));
+        }
+    }
+
+}

--- a/src/main/java/org/gbif/ipt/action/manage/OverviewAction.java
+++ b/src/main/java/org/gbif/ipt/action/manage/OverviewAction.java
@@ -105,7 +105,6 @@ public class OverviewAction extends ManagerBaseAction implements ReportHandler {
   private static final TermFactory TERM_FACTORY = TermFactory.instance();
   private final UserAccountManager userManager;
   private final ExtensionManager extensionManager;
-  private final VocabulariesManager vocabManager;
   private List<User> potentialManagers;
   private List<Extension> potentialCores;
   private List<Extension> potentialExtensions;
@@ -118,6 +117,7 @@ public class OverviewAction extends ManagerBaseAction implements ReportHandler {
   private boolean metadataModifiedSinceLastPublication;
   private boolean mappingsModifiedSinceLastPublication;
   private boolean sourcesModifiedSinceLastPublication;
+  private Map<String, String> autoPublishFrequencies;
   private StatusReport report;
   private Date now;
   private boolean unpublish = false;
@@ -127,7 +127,7 @@ public class OverviewAction extends ManagerBaseAction implements ReportHandler {
   private boolean undelete = false;
   private boolean publish = false;
   private String summary;
-  private Map<String, String> frequencies;
+
   // preview
   private GenerateDwcaFactory dwcaFactory;
   private List<String> columns;
@@ -135,17 +135,19 @@ public class OverviewAction extends ManagerBaseAction implements ReportHandler {
   private Integer mid;
   private static final int PEEK_ROWS = 100;
 
+  private final VocabulariesManager vocabManager;
+
   @Inject
   public OverviewAction(SimpleTextProvider textProvider, AppConfig cfg, RegistrationManager registrationManager,
     ResourceManager resourceManager, UserAccountManager userAccountManager, ExtensionManager extensionManager,
-    VocabulariesManager vocabManager, GenerateDwcaFactory dwcaFactory) {
+    GenerateDwcaFactory dwcaFactory, VocabulariesManager vocabManager) {
     super(textProvider, cfg, registrationManager, resourceManager);
     this.userManager = userAccountManager;
     this.extensionManager = extensionManager;
     this.emlValidator = new EmlValidator(cfg, registrationManager, textProvider);
-    this.vocabManager = vocabManager;
     this.dwcaFactory = dwcaFactory;
     this.doiAccount = registrationManager.findPrimaryDoiAgencyAccount();
+    this.vocabManager = vocabManager;
   }
 
   /**
@@ -511,15 +513,6 @@ public class OverviewAction extends ManagerBaseAction implements ReportHandler {
    */
   public boolean getConfirmOverwrite() {
     return session.get(Constants.SESSION_FILE) != null;
-  }
-
-  /**
-   * On the manage resource page page, this map is used to populate the publishing intervals dropdown.
-   *
-   * @return update frequencies map
-   */
-  public Map<String, String> getFrequencies() {
-    return frequencies;
   }
 
   /**
@@ -976,27 +969,6 @@ public class OverviewAction extends ManagerBaseAction implements ReportHandler {
     return execute();
   }
 
-  /**
-   * Populate frequencies map, representing the publishing interval choices uses have when configuring
-   * auto-publishing. The frequencies list is derived from an XML vocabulary, and will contain values in the requested
-   * locale, defaulting to English.
-   */
-  private void populateFrequencies() {
-    frequencies = new LinkedHashMap<String, String>();
-
-    if (resource.usesAutoPublishing()) {
-      frequencies.put("off", getText("autopublish.off"));
-    } else {
-      frequencies.put("", getText("autopublish.interval"));
-    }
-
-    // update frequencies list, that qualify for auto-publishing
-    Map<String, String> filteredFrequencies =
-      vocabManager.getI18nVocab(Constants.VOCAB_URI_UPDATE_FREQUENCIES, getLocaleLanguage(), false);
-    MapUtils.removeNonMatchingKeys(filteredFrequencies, MaintenanceUpdateFrequency.NON_ZERO_DAYS_UPDATE_PERIODS);
-    frequencies.putAll(filteredFrequencies);
-  }
-
   @Override
   public void prepare() {
     super.prepare();
@@ -1067,8 +1039,13 @@ public class OverviewAction extends ManagerBaseAction implements ReportHandler {
       // check if the sources have been modified since the last publication
       sourcesModifiedSinceLastPublication = setSourcesModifiedSinceLastPublication(resource);
 
-      // populate frequencies map
-      populateFrequencies();
+      // auto publish frequencies
+      autoPublishFrequencies = new LinkedHashMap<String, String>();
+
+      Map<String, String> filteredFrequencies =
+              vocabManager.getI18nVocab(Constants.VOCAB_URI_UPDATE_FREQUENCIES, getLocaleLanguage(), false);
+      MapUtils.removeNonMatchingKeys(filteredFrequencies, MaintenanceUpdateFrequency.NON_ZERO_DAYS_UPDATE_PERIODS);
+      autoPublishFrequencies.putAll(filteredFrequencies);
     }
   }
 
@@ -1156,32 +1133,6 @@ public class OverviewAction extends ManagerBaseAction implements ReportHandler {
         logProcessFailures(resource);
         LOG.info("Clearing publish event failures for resource: " + resource.getTitleAndShortname());
         resourceManager.getProcessFailures().removeAll(resource.getShortname());
-      }
-
-      // look for parameters publication mode and publication frequency
-      String pm = StringUtils.trimToNull(req.getParameter(Constants.REQ_PARAM_PUBLICATION_MODE));
-      if (!Strings.isNullOrEmpty(pm)) {
-        try {
-          // auto-publishing being turned OFF
-          if (PublicationMode.AUTO_PUBLISH_OFF == PublicationMode.valueOf(pm) && resource.usesAutoPublishing()) {
-            resourceManager.publicationModeToOff(resource);
-          }
-          // auto-publishing being turned ON, or auto-publishing settings being updated
-          else {
-            String pf = StringUtils.trimToNull(req.getParameter(Constants.REQ_PARAM_PUBLICATION_FREQUENCY));
-            if (!Strings.isNullOrEmpty(pf)) {
-              resource.setUpdateFrequency(pf);
-              resource.setPublicationMode(PublicationMode.valueOf(pm));
-            } else {
-              LOG.debug("No change to auto-publishing settings");
-            }
-          }
-        } catch (IllegalArgumentException e) {
-          LOG.error("Exception encountered while parsing parameters: " + e.getMessage(), e);
-        } finally {
-          // update frequencies map
-          populateFrequencies();
-        }
       }
 
       BigDecimal nextVersion = new BigDecimal(resource.getNextVersion().toPlainString());
@@ -1483,6 +1434,10 @@ public class OverviewAction extends ManagerBaseAction implements ReportHandler {
     return sourcesModifiedSinceLastPublication;
   }
 
+  public Map<String, String> getAutoPublishFrequencies() {
+    return autoPublishFrequencies;
+  }
+
   /**
    * Preview the first "peekRows" number of rows for a given mapping. The mapping is specified by the combination
    * of rowType and mapping ID.
@@ -1601,4 +1556,6 @@ public class OverviewAction extends ManagerBaseAction implements ReportHandler {
   public String getSummary() {
     return Strings.emptyToNull(summary);
   }
+
+
 }

--- a/src/main/java/org/gbif/ipt/config/Constants.java
+++ b/src/main/java/org/gbif/ipt/config/Constants.java
@@ -23,8 +23,13 @@ public final class Constants {
   public static final String REQ_PARAM_ID = "id";
   public static final String REQ_PARAM_SOURCE = "s";
   public static final String REQ_PARAM_VERSION = "v";
-  public static final String REQ_PARAM_PUBLICATION_MODE = "pubMode";
-  public static final String REQ_PARAM_PUBLICATION_FREQUENCY = "pubFreq";
+  public static final String REQ_PARAM_AUTO_PUBLISH_FREQUENCY = "updateFrequency";
+  public static final String REQ_PARAM_AUTO_PUBLISH_FREQUENCY_MONTH = "updateFrequencyMonth";
+  public static final String REQ_PARAM_AUTO_PUBLISH_FREQUENCY_BIMONTH = "updateFrequencyBiMonth";
+  public static final String REQ_PARAM_AUTO_PUBLISH_FREQUENCY_DAY = "updateFrequencyDay";
+  public static final String REQ_PARAM_AUTO_PUBLISH_FREQUENCY_DAYOFWEEK = "updateFrequencyDayOfWeek";
+  public static final String REQ_PARAM_AUTO_PUBLISH_FREQUENCY_HOUR = "updateFrequencyHour";
+  public static final String REQ_PARAM_AUTO_PUBLISH_FREQUENCY_MINUTE = "updateFrequencyMinute";
   public static final String DWC_ROWTYPE_OCCURRENCE = DwcTerm.Occurrence.qualifiedName();
   public static final String DWC_ROWTYPE_TAXON = DwcTerm.Taxon.qualifiedName();
   public static final String DWC_ROWTYPE_EVENT = DwcTerm.Event.qualifiedName();

--- a/src/main/java/org/gbif/ipt/model/BiMonthEnum.java
+++ b/src/main/java/org/gbif/ipt/model/BiMonthEnum.java
@@ -1,0 +1,44 @@
+package org.gbif.ipt.model;
+
+import javax.annotation.Nullable;
+
+public enum BiMonthEnum {
+    JANUARY_JULY("january_july", 0),
+    FEBRUARY_AUGUST("february_august", 1),
+    MARCH_SEPTEMBER("march_september", 2),
+    APRIL_OCTOBER("april_october", 3),
+    MAY_NOVEMBER("may_november", 4),
+    JUNE_DECEMBER("june_december", 5);
+
+    private final String identifier;
+    private final int biMonthId;
+
+    BiMonthEnum(String identifier, int biMonthId) {
+        this.identifier = identifier;
+        this.biMonthId = biMonthId;
+    }
+
+    public String getIdentifier() {
+        return identifier;
+    }
+
+    public int getBiMonthId() {
+        return biMonthId;
+    }
+
+    public static BiMonthEnum findByIdentifier(@Nullable String id) {
+        if (id != null) {
+            BiMonthEnum[] var1 = values();
+            int var2 = var1.length;
+
+            for(int var3 = 0; var3 < var2; ++var3) {
+                BiMonthEnum entry = var1[var3];
+                if (entry.getIdentifier().toLowerCase().equals(id.trim().toLowerCase())) {
+                    return entry;
+                }
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/main/java/org/gbif/ipt/model/DayEnum.java
+++ b/src/main/java/org/gbif/ipt/model/DayEnum.java
@@ -1,0 +1,45 @@
+package org.gbif.ipt.model;
+
+import javax.annotation.Nullable;
+
+public enum DayEnum {
+    MONDAY("monday", 2),
+    TUESDAY("tuesday", 3),
+    WEDNESDAY("wednesday", 4),
+    THURSDAY("thursday", 5),
+    FRIDAY("friday", 6),
+    SATURDAY("saturday", 7),
+    SUNDAY("sunday", 1);
+
+    private final String identifier;
+    private final int dayId;
+
+    DayEnum(String identifier, int dayId) {
+        this.identifier = identifier;
+        this.dayId = dayId;
+    }
+
+    public String getIdentifier() {
+        return identifier;
+    }
+
+    public int getDayId() {
+        return dayId;
+    }
+
+    public static DayEnum findByIdentifier(@Nullable String id) {
+        if (id != null) {
+            DayEnum[] var1 = values();
+            int var2 = var1.length;
+
+            for(int var3 = 0; var3 < var2; ++var3) {
+                DayEnum entry = var1[var3];
+                if (entry.getIdentifier().toLowerCase().equals(id.trim().toLowerCase())) {
+                    return entry;
+                }
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/main/java/org/gbif/ipt/model/MonthEnum.java
+++ b/src/main/java/org/gbif/ipt/model/MonthEnum.java
@@ -1,0 +1,52 @@
+package org.gbif.ipt.model;
+
+import org.gbif.metadata.eml.MaintenanceUpdateFrequency;
+
+import javax.annotation.Nullable;
+
+public enum MonthEnum {
+    JANUARY("january", 0),
+    FEBRUARY("february", 1),
+    MARCH("march", 2),
+    APRIL("april", 3),
+    MAY("may", 4),
+    JUNE("june", 5),
+    JULY("july", 6),
+    AUGUST("august", 7),
+    SEPTEMBER("september", 8),
+    OCTOBER("october", 9),
+    NOVEMBER("november", 10),
+    DECEMBER("december", 11);
+
+    private final String identifier;
+    private final int monthId;
+
+    MonthEnum(String identifier, int monthId) {
+        this.identifier = identifier;
+        this.monthId = monthId;
+    }
+
+    public String getIdentifier() {
+        return identifier;
+    }
+
+    public int getMonthId() {
+        return monthId;
+    }
+
+    public static MonthEnum findByIdentifier(@Nullable String id) {
+        if (id != null) {
+            MonthEnum[] var1 = values();
+            int var2 = var1.length;
+
+            for(int var3 = 0; var3 < var2; ++var3) {
+                MonthEnum entry = var1[var3];
+                if (entry.getIdentifier().toLowerCase().equals(id.trim().toLowerCase())) {
+                    return entry;
+                }
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/main/java/org/gbif/ipt/model/Resource.java
+++ b/src/main/java/org/gbif/ipt/model/Resource.java
@@ -69,6 +69,13 @@ public class Resource implements Serializable, Comparable<Resource> {
   private String subtype;
   // update frequency
   private MaintenanceUpdateFrequency updateFrequency;
+  // update frequency details
+  private MonthEnum updateFrequencyMonth;
+  private BiMonthEnum updateFrequencyBiMonth;
+  private Integer updateFrequencyDay;
+  private DayEnum updateFrequencyDayOfWeek;
+  private Integer updateFrequencyHour;
+  private Integer updateFrequencyMinute;
   // publication status
   private PublicationStatus status = PublicationStatus.PRIVATE;
   // publication mode
@@ -702,6 +709,35 @@ public class Resource implements Serializable, Comparable<Resource> {
     return updateFrequency;
   }
 
+  /**
+   * Return the temporal information (month, day, hour or minute) to build the next date,
+   * when update frequency is used.
+   */
+
+  public MonthEnum getUpdateFrequencyMonth() {
+    return updateFrequencyMonth;
+  }
+
+  public BiMonthEnum getUpdateFrequencyBiMonth() {
+    return updateFrequencyBiMonth;
+  }
+
+  public Integer getUpdateFrequencyDay() {
+    return updateFrequencyDay;
+  }
+
+  public DayEnum getUpdateFrequencyDayOfWeek() {
+    return updateFrequencyDayOfWeek;
+  }
+
+  public Integer getUpdateFrequencyHour() {
+    return updateFrequencyHour;
+  }
+
+  public Integer getUpdateFrequencyMinute() {
+    return updateFrequencyMinute;
+  }
+
   public String getTitle() {
     if (eml != null) {
       return eml.getTitle();
@@ -894,6 +930,54 @@ public class Resource implements Serializable, Comparable<Resource> {
     this.updateFrequency = MaintenanceUpdateFrequency.findByIdentifier(updateFrequency);
   }
 
+  /**
+   * Sets the frequency and temporal information (month, day, hour or minute) to build the next date,
+   * when update frequency is used.
+   */
+
+  public void setAutoPublishingFrequency(String frequency, String month, String biMonth, int day, String dayOfWeek, int hour, int minute) {
+    clearAutoPublishingFrequency();
+    this.updateFrequency = MaintenanceUpdateFrequency.findByIdentifier(frequency);
+    switch (this.updateFrequency) {
+      case ANNUALLY:
+        this.updateFrequencyMonth = MonthEnum.findByIdentifier(month);
+        this.updateFrequencyDay = day;
+        this.updateFrequencyHour = hour;
+        this.updateFrequencyMinute = minute;
+        break;
+      case BIANNUALLY:
+        this.updateFrequencyBiMonth = BiMonthEnum.findByIdentifier(biMonth);
+        this.updateFrequencyDay = day;
+        this.updateFrequencyHour = hour;
+        this.updateFrequencyMinute = minute;
+        break;
+      case MONTHLY:
+        this.updateFrequencyDay = day;
+        this.updateFrequencyHour = hour;
+        this.updateFrequencyMinute = minute;
+        break;
+      case WEEKLY:
+        this.updateFrequencyDayOfWeek = DayEnum.findByIdentifier(dayOfWeek);
+        this.updateFrequencyHour = hour;
+        this.updateFrequencyMinute = minute;
+        break;
+      case DAILY:
+        this.updateFrequencyHour = hour;
+        this.updateFrequencyMinute = minute;
+        break;
+    }
+  }
+
+  public void clearAutoPublishingFrequency() {
+    this.updateFrequency = null;
+    this.updateFrequencyMonth = null;
+    this.updateFrequencyBiMonth = null;
+    this.updateFrequencyDay = null;
+    this.updateFrequencyDayOfWeek = null;
+    this.updateFrequencyHour = null;
+    this.updateFrequencyMinute = null;
+  }
+
   public void setTitle(String title) {
     if (eml != null) {
       this.eml.setTitle(title);
@@ -914,6 +998,14 @@ public class Resource implements Serializable, Comparable<Resource> {
    */
   public boolean usesAutoPublishing() {
     return publicationMode == PublicationMode.AUTO_PUBLISH_ON && updateFrequency != null;
+  }
+
+  /**
+   * Check if the resource is using the old configuration for auto-publishing
+   */
+  public boolean isDeprecatedAutoPublishingConfiguration() {
+    // updateFrequenceMinute has a value between 0 and 59 if the new configuration is used
+    return usesAutoPublishing() && (updateFrequencyMinute == null);
   }
 
   /**

--- a/src/main/java/org/gbif/ipt/service/manage/ResourceManager.java
+++ b/src/main/java/org/gbif/ipt/service/manage/ResourceManager.java
@@ -279,11 +279,11 @@ public interface ResourceManager {
   void restoreVersion(Resource resource, BigDecimal rollingBack, @Nullable BaseAction action);
 
   /**
-   * Turn resource publicationMode to OFF.
+   * Update the resource publicationMode.
    *
    * @param resource resource
    */
-  void publicationModeToOff(Resource resource);
+  void updatePublicationMode(Resource resource);
 
   /**
    * Updates the resource's alternative identifier for the IPT URL to the resource, and saves the EML afterward.

--- a/src/main/java/org/gbif/ipt/service/manage/impl/ResourceManagerImpl.java
+++ b/src/main/java/org/gbif/ipt/service/manage/impl/ResourceManagerImpl.java
@@ -74,6 +74,7 @@ import org.gbif.ipt.utils.ResourceUtils;
 import org.gbif.metadata.eml.Eml;
 import org.gbif.metadata.eml.EmlFactory;
 import org.gbif.metadata.eml.KeywordSet;
+import org.gbif.metadata.eml.MaintenanceUpdateFrequency;
 import org.gbif.utils.file.CompressionUtil;
 import org.gbif.utils.file.CompressionUtil.UnsupportedCompressionType;
 
@@ -1349,7 +1350,7 @@ public class ResourceManagerImpl extends BaseManager implements ResourceManager,
     // set last published date
     resource.setLastPublished(new Date());
     // set next published date (if resource configured for auto-publishing)
-    updateNextPublishedDate(resource);
+    updateNextPublishedDate(new Date(), resource);
     // register/update DOI
     executeDoiWorkflow(resource, version, resource.getReplacedEmlVersion(), action);
     // finalise/update version history
@@ -2249,6 +2250,16 @@ public class ResourceManagerImpl extends BaseManager implements ResourceManager,
       : processReports.get(shortname).getMessages();
   }
 
+  @Override
+  public void updatePublicationMode(Resource resource) {
+    if (resource.usesAutoPublishing()) {
+      updateNextPublishedDate(new Date(), resource);
+    }
+    else {
+      resource.setNextPublished(null);
+    }
+  }
+
   /**
    * Updates the date the resource is scheduled to be published next. The resource must have been configured with
    * a maintenance update frequency that is suitable for auto-publishing (annually, biannually, monthly, weekly,
@@ -2258,26 +2269,98 @@ public class ResourceManagerImpl extends BaseManager implements ResourceManager,
    *
    * @throws PublicationException if the next published date cannot be set for any reason
    */
-  private void updateNextPublishedDate(Resource resource) throws PublicationException {
+  protected void updateNextPublishedDate(Date currentDate, Resource resource) throws PublicationException {
     if (resource.usesAutoPublishing()) {
       try {
         LOG.debug("Updating next published date of resource: " + resource.getShortname());
 
-        // get the time now, from this the next published date will be calculated
-        Date now = new Date();
+        Date nextPublished = null;
 
-        // get update period in days
-        int days = resource.getUpdateFrequency().getPeriodInDays();
+        // get update period
+        MaintenanceUpdateFrequency frequency = resource.getUpdateFrequency();
 
-        // calculate next published date
         Calendar cal = Calendar.getInstance();
-        cal.setTime(now);
-        cal.add(Calendar.DATE, days);
-        Date nextPublished = cal.getTime();
+        cal.setTime(currentDate);
+
+        // Using the old auto publish configuration
+        if (resource.isDeprecatedAutoPublishingConfiguration()) {
+          // use predefined period for previous IPT version
+          int days = resource.getUpdateFrequency().getPeriodInDays();
+          cal.add(Calendar.DATE, days);
+          nextPublished = cal.getTime();
+        }
+        // Using the new auto publish configuration
+        else {
+          cal.set(Calendar.SECOND, 0);
+          cal.set(Calendar.MILLISECOND, 0);
+          switch (frequency) {
+            case ANNUALLY:
+              cal.set(Calendar.MONTH, resource.getUpdateFrequencyMonth().getMonthId());
+              cal.set(Calendar.DAY_OF_MONTH, resource.getUpdateFrequencyDay());
+              cal.set(Calendar.HOUR_OF_DAY, resource.getUpdateFrequencyHour());
+              cal.set(Calendar.MINUTE, resource.getUpdateFrequencyMinute());
+              nextPublished = cal.getTime();
+              if (nextPublished.before(currentDate)) {
+                cal.add(Calendar.YEAR, 1);
+                nextPublished = cal.getTime();
+              }
+              break;
+            case BIANNUALLY:
+              cal.set(Calendar.MONTH, resource.getUpdateFrequencyBiMonth().getBiMonthId());
+              cal.set(Calendar.DAY_OF_MONTH, resource.getUpdateFrequencyDay());
+              cal.set(Calendar.HOUR_OF_DAY, resource.getUpdateFrequencyHour());
+              cal.set(Calendar.MINUTE, resource.getUpdateFrequencyMinute());
+              nextPublished = cal.getTime();
+              if (nextPublished.before(currentDate)) {
+                cal.add(Calendar.MONTH, 6);
+                nextPublished = cal.getTime();
+                if (nextPublished.before(currentDate)) {
+                  cal.add(Calendar.MONTH, 6);
+                  nextPublished = cal.getTime();
+                }
+              }
+              break;
+            case MONTHLY:
+              cal.set(Calendar.DAY_OF_MONTH, resource.getUpdateFrequencyDay());
+              cal.set(Calendar.HOUR_OF_DAY, resource.getUpdateFrequencyHour());
+              cal.set(Calendar.MINUTE, resource.getUpdateFrequencyMinute());
+              nextPublished = cal.getTime();
+              if (nextPublished.before(currentDate)) {
+                cal.add(Calendar.MONTH, 1);
+                nextPublished = cal.getTime();
+              }
+              break;
+            case WEEKLY:
+              cal.set(Calendar.DAY_OF_WEEK, resource.getUpdateFrequencyDayOfWeek().getDayId());
+              cal.set(Calendar.HOUR_OF_DAY, resource.getUpdateFrequencyHour());
+              cal.set(Calendar.MINUTE, resource.getUpdateFrequencyMinute());
+              nextPublished = cal.getTime();
+              if (nextPublished.before(currentDate)) {
+                cal.add(Calendar.WEEK_OF_YEAR, 1);
+                nextPublished = cal.getTime();
+              }
+              break;
+            case DAILY:
+              cal.set(Calendar.HOUR_OF_DAY, resource.getUpdateFrequencyHour());
+              cal.set(Calendar.MINUTE, resource.getUpdateFrequencyMinute());
+              nextPublished = cal.getTime();
+              if (nextPublished.before(currentDate)) {
+                cal.add(Calendar.DAY_OF_YEAR, 1);
+                nextPublished = cal.getTime();
+              }
+              break;
+          }
+        }
 
         // alert user that auto publishing has been turned on
         if (resource.getNextPublished() == null) {
           LOG.debug("Auto-publishing turned on");
+        }
+
+        if (nextPublished == null) {
+          String msg = "Error to compute the next publication date";
+          LOG.error(msg);
+          throw new PublicationException(PublicationException.TYPE.SCHEDULING, msg);
         }
 
         // set next published date
@@ -2286,30 +2369,15 @@ public class ResourceManagerImpl extends BaseManager implements ResourceManager,
         // log
         LOG.debug("The next publication date is: " + nextPublished.toString());
       } catch (Exception e) {
+        resource.setNextPublished(null);
         // add error message that explains the consequence of the error to user
         String msg = "Auto-publishing failed: " + e.getMessage();
         LOG.error(msg, e);
         throw new PublicationException(PublicationException.TYPE.SCHEDULING, msg, e);
       }
     } else {
-      LOG.debug("Resource: " + resource.getShortname() + " has not been configured to use auto-publishing");
-    }
-  }
-
-  public void publicationModeToOff(Resource resource) {
-    if (PublicationMode.AUTO_PUBLISH_OFF == resource.getPublicationMode()) {
-      throw new InvalidConfigException(TYPE.AUTO_PUBLISHING_ALREADY_OFF,
-        "Auto-publishing mode has already been switched off");
-    } else if (PublicationMode.AUTO_PUBLISH_ON == resource.getPublicationMode()) {
-      // update publicationMode to OFF
-      resource.setPublicationMode(PublicationMode.AUTO_PUBLISH_OFF);
-      // clear frequency
-      resource.setUpdateFrequency(null);
-      // clear next published date
       resource.setNextPublished(null);
-      LOG.debug("Auto-publishing turned off");
-      // save change to resource
-      save(resource);
+      LOG.debug("Resource: " + resource.getShortname() + " has not been configured to use auto-publishing");
     }
   }
 

--- a/src/main/resources/ApplicationResources_en.properties
+++ b/src/main/resources/ApplicationResources_en.properties
@@ -1428,13 +1428,58 @@ restore.resource.success=Restored version #{0} of resource {1} after publishing 
 restore.resource.failed=Restoring version #{0} of resource {1} failed: {2}
 
 # Auto-publishing
-autopublish=Auto-publishing
-autopublish.off=Turn off
-autopublish.update=Publish & change auto-publishing interval
-autopublish.activate=Publish & turn on auto-publishing
-autopublish.disable=Publish & turn off auto-publishing
-autopublish.interval=Select interval
-autopublish.help=To <strong>turn on</strong> automated publishing, select one of the 5 publishing intervals and then press publish. To <strong>change</strong> the automated publishing interval, select a different publishing interval and press publish. To <strong>turn off</strong> automated publishing, select "Turn off" and then press publish.
+
+manage.overview.autopublish.title=Auto-publishing
+manage.overview.autopublish.description=You can activate auto-publishing here and define the publication schedule for this resource (frequency and additionnal information)
+manage.overview.autopublish.intro.activated=Auto-publish is activated. Your resource will be automatically published as scheduled below.
+manage.overview.autopublish.intro.deactivated=Auto-publish is deactivated. Your resource should be published manually with the Publish button.
+manage.overview.autopublish.deprecated.warning.button=The configuration is deprecated. Please update it.
+manage.overview.autopublish.deprecated.warning.description=<strong>This configuration is deprecated</strong>. Please update it.
+manage.overview.autopublish.publication.frequency=Frequency
+manage.overview.autopublish.publication.next.date=Next publication date
+
+manage.autopublish.title=Auto-publishing
+manage.autopublish.intro=Please select one of the <strong>5 publishing intervals</strong> to activate the auto-publishing.<br/>Fill in the additional frequency information and press Save.<br/><br/>To <strong>turn off</strong> the auto-publishing, select "Turn off" in the list and press Save<br/>(this will not generate a new version of the resource).
+manage.autopublish.intro.annually=This resource will be published automatically once a year.
+manage.autopublish.intro.biannually=This resource will be published automatically twice a year.
+manage.autopublish.intro.monthly=This resource will be published automatically every month.
+manage.autopublish.intro.weekly=This resource will be published automatically every week.
+manage.autopublish.intro.daily=This resource will be published automatically every day.
+manage.autopublish.intro.off=This resource will be published manually.
+
+manage.autopublish.help.annually=<strong>month</strong> and <strong>day of month</strong>
+manage.autopublish.help.biannually=<strong>two months</strong> and <strong>day of month</strong>
+manage.autopublish.help.monthly=<strong>day of month</strong>
+manage.autopublish.help.weekly=<strong>day of week</strong>
+manage.autopublish.help.hour=<strong>hours</strong> and <strong>minutes</strong> (related to your IPT server timezone)
+
+manage.autopublish.frequency=Auto-publishing frequency
+manage.autopublish.off=Turn off
+manage.autopublish.january=January
+manage.autopublish.february=February
+manage.autopublish.march=March
+manage.autopublish.april=April
+manage.autopublish.may=May
+manage.autopublish.june=June
+manage.autopublish.july=July
+manage.autopublish.august=August
+manage.autopublish.september=September
+manage.autopublish.october=October
+manage.autopublish.november=November
+manage.autopublish.december=December
+manage.autopublish.monday=Monday
+manage.autopublish.tuesday=Tuesday
+manage.autopublish.wednesday=Wednesday
+manage.autopublish.thursday=Thursday
+manage.autopublish.friday=Friday
+manage.autopublish.saturday=Saturday
+manage.autopublish.sunday=Sunday
+manage.autopublish.january_july=January/July
+manage.autopublish.february_august=February/August
+manage.autopublish.march_september=March/September
+manage.autopublish.april_october=April/October
+manage.autopublish.may_november=May/November
+manage.autopublish.june_december=June/December
 
 # Struts2 overrides
 struts.messages.upload.error.SizeLimitExceededException=The uploaded file is too large! Max size allowed is {0} bytes but request was {1} bytes. To work around this problem, you can try compressing the file (with zip or gzip), loading the data into one of the many databases supported by the IPT, or splitting the file up. Please refer to the user manual for more information.

--- a/src/main/resources/ApplicationResources_es.properties
+++ b/src/main/resources/ApplicationResources_es.properties
@@ -1428,13 +1428,58 @@ restore.resource.success=Restaurada la versión \#{0} del recurso {1} tras la fa
 restore.resource.failed=Falló la restauración de la versión \#{0} del recurso {1}\: {2}
 
 # Auto-publishing
-autopublish=Autopublicación
-autopublish.off=Desactivar
-autopublish.update=Publicar y cambiar la frecuencia de autopublicación
-autopublish.activate=Publicar y activar la autopublicación
-autopublish.disable=Publicar y desactivar la autopublicación
-autopublish.interval=Seleccionar la frecuencia
-autopublish.help=Para <strong>activar</strong> la autopublicación, seleccione una de las 5 frecuencias de publicación y presione el botón Publicar y activar la autopublicación. Para <strong>cambiar</strong> la frecuencia de autopublicación, seleccione una frecuencia de publicación diferente y presione el botón Publicar y cambiar la frecuencia de autopublicación. Para <strong>desactivar</strong> la autopublicación, seleccione "Desactivar" y presione el botón Publicar y desactivar la autopublicación.
+
+manage.overview.autopublish.title=Autopublicación
+manage.overview.autopublish.description=You can activate auto-publishing here and define the publication schedule for this resource (frequency and additionnal information)
+manage.overview.autopublish.intro.activated=Auto-publish is activated. Your resource will be automatically published as scheduled below.
+manage.overview.autopublish.intro.deactivated=Auto-publish is deactivated. Your resource should be published manually with the Publish button.
+manage.overview.autopublish.deprecated.warning.button=The configuration is deprecated. Please update it.
+manage.overview.autopublish.deprecated.warning.description=<strong>This configuration is deprecated</strong>. Please update it.
+manage.overview.autopublish.publication.frequency=Frequency
+manage.overview.autopublish.publication.next.date=Next publication date
+
+manage.autopublish.title=Autopublicación
+manage.autopublish.intro=Please select one of the <strong>5 publishing intervals</strong> to activate the auto-publishing.<br/>Fill in the additional frequency information and press Save.<br/><br/>To <strong>turn off</strong> the auto-publishing, select "Turn off" in the list and press Save<br/>(this will not generate a new version of the resource).
+manage.autopublish.intro.annually=This resource will be published automatically once a year.
+manage.autopublish.intro.biannually=This resource will be published automatically twice a year.
+manage.autopublish.intro.monthly=This resource will be published automatically every month.
+manage.autopublish.intro.weekly=This resource will be published automatically every week.
+manage.autopublish.intro.daily=This resource will be published automatically every day.
+manage.autopublish.intro.off=This resource will be published manually.
+
+manage.autopublish.help.annually=<strong>month</strong> and <strong>day of month</strong>
+manage.autopublish.help.biannually=<strong>two months</strong> and <strong>day of month</strong>
+manage.autopublish.help.monthly=<strong>day of month</strong>
+manage.autopublish.help.weekly=<strong>day of week</strong>
+manage.autopublish.help.hour=<strong>hours</strong> and <strong>minutes</strong> (related to your IPT server timezone)
+
+manage.autopublish.frequency=Auto-publishing frequency
+manage.autopublish.off=Desactivar
+manage.autopublish.january=January
+manage.autopublish.february=February
+manage.autopublish.march=March
+manage.autopublish.april=April
+manage.autopublish.may=May
+manage.autopublish.june=June
+manage.autopublish.july=July
+manage.autopublish.august=August
+manage.autopublish.september=September
+manage.autopublish.october=October
+manage.autopublish.november=November
+manage.autopublish.december=December
+manage.autopublish.monday=Monday
+manage.autopublish.tuesday=Tuesday
+manage.autopublish.wednesday=Wednesday
+manage.autopublish.thursday=Thursday
+manage.autopublish.friday=Friday
+manage.autopublish.saturday=Saturday
+manage.autopublish.sunday=Sunday
+manage.autopublish.january_july=January/July
+manage.autopublish.february_august=February/August
+manage.autopublish.march_september=March/September
+manage.autopublish.april_october=April/October
+manage.autopublish.may_november=May/November
+manage.autopublish.june_december=June/December
 
 # Struts2 overrides
 struts.messages.upload.error.SizeLimitExceededException=¡El archivo es demasiado grande\! El tamaño máximo permitido es de {0} bytes, su archivo es de {1} bytes. Para solucionar este problema, intente comprimir el archivo (con zip o gzip), cargar los datos en una de las muchas bases de datos soportados por el IPT o dividiendo el archivo. Por favor consulte el manual del usuario para obtener más información.

--- a/src/main/resources/ApplicationResources_fa.properties
+++ b/src/main/resources/ApplicationResources_fa.properties
@@ -1428,13 +1428,58 @@ restore.resource.success=نسخه بازیابی شده{0} \# از منابع {1
 restore.resource.failed=بازگرداندن نسخه \#{0} از منبع {1} انجام نشد\: {2}
 
 # Auto-publishing
-autopublish=انتشار خودکار
-autopublish.off=خاموش
-autopublish.update=نشر و تغییر، نشر خودکار با فاصله زمانی
-autopublish.activate=نشر و فعال کردن انتشار خودکار
-autopublish.disable=نشر و غیر فعال کردن انتشار خودکار
-autopublish.interval=انتخاب فاصله
-autopublish.help=برای <strong>فعال کردن</strong> خودکار انتشارات یکی از 5 فواصل انتشار را انتخاب کنید و سپس انتشار مطبوعات. برای <strong>تغییر</strong> فاصله انتشار خودکار فاصله انتشارات مختلف انتخاب و نشر مطبوعات. برای <strong>غیر فعال کردن</strong> خودکار "را خاموش انتشارات, را انتخاب کنید" و سپس انتشار مطبوعات است.
+
+manage.overview.autopublish.title=انتشار خودکار
+manage.overview.autopublish.description=You can activate auto-publishing here and define the publication schedule for this resource (frequency and additionnal information)
+manage.overview.autopublish.intro.activated=Auto-publish is activated. Your resource will be automatically published as scheduled below.
+manage.overview.autopublish.intro.deactivated=Auto-publish is deactivated. Your resource should be published manually with the Publish button.
+manage.overview.autopublish.deprecated.warning.button=The configuration is deprecated. Please update it.
+manage.overview.autopublish.deprecated.warning.description=<strong>This configuration is deprecated</strong>. Please update it.
+manage.overview.autopublish.publication.frequency=Frequency
+manage.overview.autopublish.publication.next.date=Next publication date
+
+manage.autopublish.title=انتشار خودکار
+manage.autopublish.intro=Please select one of the <strong>5 publishing intervals</strong> to activate the auto-publishing.<br/>Fill in the additional frequency information and press Save.<br/><br/>To <strong>turn off</strong> the auto-publishing, select "Turn off" in the list and press Save<br/>(this will not generate a new version of the resource).
+manage.autopublish.intro.annually=This resource will be published automatically once a year.
+manage.autopublish.intro.biannually=This resource will be published automatically twice a year.
+manage.autopublish.intro.monthly=This resource will be published automatically every month.
+manage.autopublish.intro.weekly=This resource will be published automatically every week.
+manage.autopublish.intro.daily=This resource will be published automatically every day.
+manage.autopublish.intro.off=This resource will be published manually.
+
+manage.autopublish.help.annually=<strong>month</strong> and <strong>day of month</strong>
+manage.autopublish.help.biannually=<strong>two months</strong> and <strong>day of month</strong>
+manage.autopublish.help.monthly=<strong>day of month</strong>
+manage.autopublish.help.weekly=<strong>day of week</strong>
+manage.autopublish.help.hour=<strong>hours</strong> and <strong>minutes</strong> (related to your IPT server timezone)
+
+manage.autopublish.frequency=Auto-publishing frequency
+manage.autopublish.off=خاموش
+manage.autopublish.january=January
+manage.autopublish.february=February
+manage.autopublish.march=March
+manage.autopublish.april=April
+manage.autopublish.may=May
+manage.autopublish.june=June
+manage.autopublish.july=July
+manage.autopublish.august=August
+manage.autopublish.september=September
+manage.autopublish.october=October
+manage.autopublish.november=November
+manage.autopublish.december=December
+manage.autopublish.monday=Monday
+manage.autopublish.tuesday=Tuesday
+manage.autopublish.wednesday=Wednesday
+manage.autopublish.thursday=Thursday
+manage.autopublish.friday=Friday
+manage.autopublish.saturday=Saturday
+manage.autopublish.sunday=Sunday
+manage.autopublish.january_july=January/July
+manage.autopublish.february_august=February/August
+manage.autopublish.march_september=March/September
+manage.autopublish.april_october=April/October
+manage.autopublish.may_november=May/November
+manage.autopublish.june_december=June/December
 
 # Struts2 overrides
 struts.messages.upload.error.SizeLimitExceededException=فایل ارسالی بیش از حد بزرگ است\! حداکثر اندازه مجاز {0} بایت است اما درخواست {1} بایت بود. به کار در اطراف این مشکل، شما می توانید سعی کنید حال فشرده کردن پرونده (با زیپ و یا gzip) بارگذاری داده ها به یکی از بسیاری از پایگاه داده های پشتیبانی شده توسط IPT یا تقسیم فایل. لطفا به کتابچه راهنمای کاربر برای اطلاعات بیشتر مراجعه کنید.

--- a/src/main/resources/ApplicationResources_fr.properties
+++ b/src/main/resources/ApplicationResources_fr.properties
@@ -1428,13 +1428,58 @@ restore.resource.success=La ressource {1} en version \#{0} a été restaurée ap
 restore.resource.failed=La restauration de la ressource {1} en version {0} a échoué\: {2}
 
 # Auto-publishing
-autopublish=Publication automatique
-autopublish.off=Désactiver
-autopublish.update=Publier & modifier la publication automatique
-autopublish.activate=Publier & activer la publication automatique
-autopublish.disable=Publier & désactiver la publication automatique
-autopublish.interval=Sélectionnez l''intervalle
-autopublish.help=Pour <strong>activer</strong> la publication automatique, sélectionnez l''un des 5 intervalles de publication, puis appuyez sur publier. Pour <strong>modifier</strong> l''intervalle de publication automatique, sélectionnez un intervalle de publication différent et appuyez sur publier. Pour <strong>désactiver</strong> la publication automatique, sélectionnez "Désactiver" puis appuyez sur publier.
+
+manage.overview.autopublish.title=Publication automatique
+manage.overview.autopublish.description=Vous pouvez activer ici la publication automatique, et définir le calendrier de publication (fréquence et informations supplémentaires)
+manage.overview.autopublish.intro.activated=La publication automatique est activée. Votre ressource sera automatiquement publiée comme planifiée ci-dessous.
+manage.overview.autopublish.intro.deactivated=La publication automatique est désactivée. Votre ressource doit être publiée manuellement avec le bouton Publier.
+manage.overview.autopublish.deprecated.warning.button=La configuration est obsolète. Veuillez la mettre à jour.
+manage.overview.autopublish.deprecated.warning.description=<strong>Cette configuration est obsolète</strong>. Veuillez la mettre à jour.
+manage.overview.autopublish.publication.frequency=Fréquence
+manage.overview.autopublish.publication.next.date=Date de la prochaine publication
+
+manage.autopublish.title=Publication automatique
+manage.autopublish.intro=Veuillez sélectionner l''une des <strong>5 fréquences de publication</strong> pour activer la publication automatique.<br/>Remplissez les informations supplémentaires et appuyez sur Enregistrer.<br/><br/>Pour <strong>désactiver</strong> la publication automatique, sélectionnez "Désactiver" dans la liste et appuyez sur Enregistrer (cela ne générera pas de nouvelle version de la ressource).
+manage.autopublish.intro.annually=Cette ressource sera publiée automatiquement une fois par an.
+manage.autopublish.intro.biannually=Cette ressource sera publiée automatiquement deux fois par an.
+manage.autopublish.intro.monthly=Cette ressource sera publiée automatiquement chaque mois.
+manage.autopublish.intro.weekly=Cette ressource sera publiée automatiquement chaque semaine.
+manage.autopublish.intro.daily=Cette ressource sera publiée automatiquement chaque jour.
+manage.autopublish.intro.off=Cette ressource sera publiée manuellement.
+
+manage.autopublish.help.annually=<strong>mois</strong> et <strong>jour du mois</strong>
+manage.autopublish.help.biannually=<strong>deux mois</strong> et <strong>jour du mois</strong>
+manage.autopublish.help.monthly=<strong>jour du mois</strong>
+manage.autopublish.help.weekly=<strong>jour de la semaine</strong>
+manage.autopublish.help.hour=<strong>heures</strong> et <strong>minutes</strong> (liées au fuseau horaire de votre serveur IPT)
+
+manage.autopublish.frequency=Fréquence de publication automatique
+manage.autopublish.off=Désactiver
+manage.autopublish.january=Janvier
+manage.autopublish.february=Février
+manage.autopublish.march=Mars
+manage.autopublish.april=Avril
+manage.autopublish.may=Mai
+manage.autopublish.june=Juin
+manage.autopublish.july=Juillet
+manage.autopublish.august=Août
+manage.autopublish.september=Septembre
+manage.autopublish.october=Octobre
+manage.autopublish.november=Novembre
+manage.autopublish.december=Décembre
+manage.autopublish.monday=Lundi
+manage.autopublish.tuesday=Mardi
+manage.autopublish.wednesday=Mercredi
+manage.autopublish.thursday=Jeudi
+manage.autopublish.friday=Vendredi
+manage.autopublish.saturday=Samedi
+manage.autopublish.sunday=Dimanche
+manage.autopublish.january_july=Janvier/Juillet
+manage.autopublish.february_august=Février/Août
+manage.autopublish.march_september=Mars/Septembre
+manage.autopublish.april_october=Avril/Octobre
+manage.autopublish.may_november=Mai/Novembre
+manage.autopublish.june_december=Juin/Décembre
 
 # Struts2 overrides
 struts.messages.upload.error.SizeLimitExceededException=Le fichier transféré est trop grand \! La taille maximum autorisée est de {0} octets mais la requête était de {1} octets. Pour contourner ce problème, vous pouvez essayer de compresser le fichier (avec zip ou gzip), de charger les données dans une des nombreuses bases de données prises en charge par l''IPT ou de fractionner le fichier. Veuillez vous référer au manuel d''utilisation pour plus d''informations.

--- a/src/main/resources/ApplicationResources_ja.properties
+++ b/src/main/resources/ApplicationResources_ja.properties
@@ -1428,13 +1428,58 @@ restore.resource.success=公開失敗の後、リソース{1}のヴァージョ�
 restore.resource.failed=リソース{1}のヴァージョン\#{0}の修復に失敗しました。
 
 # Auto-publishing
-autopublish=自動公開
-autopublish.off=終了
-autopublish.update=公開　＆　自動公開の間隔
-autopublish.activate=公開　＆　自動公開ON
-autopublish.disable=公開　＆　自動公開OFF
-autopublish.interval=頻度を選択
-autopublish.help=自動公開を<strong>ON</strong>にする時は、５つの公開間隔(スケジュール）の中から１つを選び、publishを押します。公開間隔を<strong>変更する</strong>時は、異なる間隔(スケジュール）を選んでpublishを押します。自動公開を<strong>OFF</strong>にする場合には"Turn off"を選んでpublishを押します。
+
+manage.overview.autopublish.title=自動公開
+manage.overview.autopublish.description=You can activate auto-publishing here and define the publication schedule for this resource (frequency and additionnal information)
+manage.overview.autopublish.intro.activated=Auto-publish is activated. Your resource will be automatically published as scheduled below.
+manage.overview.autopublish.intro.deactivated=Auto-publish is deactivated. Your resource should be published manually with the Publish button.
+manage.overview.autopublish.deprecated.warning.button=The configuration is deprecated. Please update it.
+manage.overview.autopublish.deprecated.warning.description=<strong>This configuration is deprecated</strong>. Please update it.
+manage.overview.autopublish.publication.frequency=Frequency
+manage.overview.autopublish.publication.next.date=Next publication date
+
+manage.autopublish.title=自動公開
+manage.autopublish.intro=Please select one of the <strong>5 publishing intervals</strong> to activate the auto-publishing.<br/>Fill in the additional frequency information and press Save.<br/><br/>To <strong>turn off</strong> the auto-publishing, select "Turn off" in the list and press Save<br/>(this will not generate a new version of the resource).
+manage.autopublish.intro.annually=This resource will be published automatically once a year.
+manage.autopublish.intro.biannually=This resource will be published automatically twice a year.
+manage.autopublish.intro.monthly=This resource will be published automatically every month.
+manage.autopublish.intro.weekly=This resource will be published automatically every week.
+manage.autopublish.intro.daily=This resource will be published automatically every day.
+manage.autopublish.intro.off=This resource will be published manually.
+
+manage.autopublish.help.annually=<strong>month</strong> and <strong>day of month</strong>
+manage.autopublish.help.biannually=<strong>two months</strong> and <strong>day of month</strong>
+manage.autopublish.help.monthly=<strong>day of month</strong>
+manage.autopublish.help.weekly=<strong>day of week</strong>
+manage.autopublish.help.hour=<strong>hours</strong> and <strong>minutes</strong> (related to your IPT server timezone)
+
+manage.autopublish.frequency=Auto-publishing frequency
+manage.autopublish.off=終了
+manage.autopublish.january=January
+manage.autopublish.february=February
+manage.autopublish.march=March
+manage.autopublish.april=April
+manage.autopublish.may=May
+manage.autopublish.june=June
+manage.autopublish.july=July
+manage.autopublish.august=August
+manage.autopublish.september=September
+manage.autopublish.october=October
+manage.autopublish.november=November
+manage.autopublish.december=December
+manage.autopublish.monday=Monday
+manage.autopublish.tuesday=Tuesday
+manage.autopublish.wednesday=Wednesday
+manage.autopublish.thursday=Thursday
+manage.autopublish.friday=Friday
+manage.autopublish.saturday=Saturday
+manage.autopublish.sunday=Sunday
+manage.autopublish.january_july=January/July
+manage.autopublish.february_august=February/August
+manage.autopublish.march_september=March/September
+manage.autopublish.april_october=April/October
+manage.autopublish.may_november=May/November
+manage.autopublish.june_december=June/December
 
 # Struts2 overrides
 struts.messages.upload.error.SizeLimitExceededException=アップロードされたファイルが大きすぎます ！許容最大サイズは {0} バイトですが、リクエストサイズは {1} バイトでした。この問題を回避するために、ファイルの圧縮 (zip と gzip) を試みてください。IPT でサポートされている複数のデータベースのいずれかにデータを流し込むか、ファイルを分割します。詳細についてはユーザー マニュアルを参照してください。

--- a/src/main/resources/ApplicationResources_ku.properties
+++ b/src/main/resources/ApplicationResources_ku.properties
@@ -1427,13 +1427,58 @@ restore.resource.success=Restored version \#{0} of resource {1} after publishing
 restore.resource.failed=Restoring version \#{0} of resource {1} failed\: {2}
 
 # Auto-publishing
-autopublish=Auto-publishing
-autopublish.off=Turn off
-autopublish.update=Publish & change auto-publishing interval
-autopublish.activate=Publish & turn on auto-publishing
-autopublish.disable=Publish & turn off auto-publishing
-autopublish.interval=Select interval
-autopublish.help=To <strong>turn on</strong> automated publishing, select one of the 5 publishing intervals and then press publish. To <strong>change</strong> the automated publishing interval, select a different publishing interval and press publish. To <strong>turn off</strong> automated publishing, select "Turn off" and then press publish.
+
+manage.overview.autopublish.title=Auto-publishing
+manage.overview.autopublish.description=You can activate auto-publishing here and define the publication schedule for this resource (frequency and additionnal information)
+manage.overview.autopublish.intro.activated=Auto-publish is activated. Your resource will be automatically published as scheduled below.
+manage.overview.autopublish.intro.deactivated=Auto-publish is deactivated. Your resource should be published manually with the Publish button.
+manage.overview.autopublish.deprecated.warning.button=The configuration is deprecated. Please update it.
+manage.overview.autopublish.deprecated.warning.description=<strong>This configuration is deprecated</strong>. Please update it.
+manage.overview.autopublish.publication.frequency=Frequency
+manage.overview.autopublish.publication.next.date=Next publication date
+
+manage.autopublish.title=Auto-publishing
+manage.autopublish.intro=Please select one of the <strong>5 publishing intervals</strong> to activate the auto-publishing.<br/>Fill in the additional frequency information and press Save.<br/><br/>To <strong>turn off</strong> the auto-publishing, select "Turn off" in the list and press Save<br/>(this will not generate a new version of the resource).
+manage.autopublish.intro.annually=This resource will be published automatically once a year.
+manage.autopublish.intro.biannually=This resource will be published automatically twice a year.
+manage.autopublish.intro.monthly=This resource will be published automatically every month.
+manage.autopublish.intro.weekly=This resource will be published automatically every week.
+manage.autopublish.intro.daily=This resource will be published automatically every day.
+manage.autopublish.intro.off=This resource will be published manually.
+
+manage.autopublish.help.annually=<strong>month</strong> and <strong>day of month</strong>
+manage.autopublish.help.biannually=<strong>two months</strong> and <strong>day of month</strong>
+manage.autopublish.help.monthly=<strong>day of month</strong>
+manage.autopublish.help.weekly=<strong>day of week</strong>
+manage.autopublish.help.hour=<strong>hours</strong> and <strong>minutes</strong> (related to your IPT server timezone)
+
+manage.autopublish.frequency=Auto-publishing frequency
+manage.autopublish.off=Turn off
+manage.autopublish.january=January
+manage.autopublish.february=February
+manage.autopublish.march=March
+manage.autopublish.april=April
+manage.autopublish.may=May
+manage.autopublish.june=June
+manage.autopublish.july=July
+manage.autopublish.august=August
+manage.autopublish.september=September
+manage.autopublish.october=October
+manage.autopublish.november=November
+manage.autopublish.december=December
+manage.autopublish.monday=Monday
+manage.autopublish.tuesday=Tuesday
+manage.autopublish.wednesday=Wednesday
+manage.autopublish.thursday=Thursday
+manage.autopublish.friday=Friday
+manage.autopublish.saturday=Saturday
+manage.autopublish.sunday=Sunday
+manage.autopublish.january_july=January/July
+manage.autopublish.february_august=February/August
+manage.autopublish.march_september=March/September
+manage.autopublish.april_october=April/October
+manage.autopublish.may_november=May/November
+manage.autopublish.june_december=June/December
 
 # Struts2 overrides
 struts.messages.upload.error.SizeLimitExceededException=The uploaded file is too large\! Max size allowed is {0} bytes but request was {1} bytes. To work around this problem, you can try compressing the file (with zip or gzip), loading the data into one of the many databases supported by the IPT, or splitting the file up. Please refer to the user manual for more information.

--- a/src/main/resources/ApplicationResources_pt.properties
+++ b/src/main/resources/ApplicationResources_pt.properties
@@ -1428,13 +1428,58 @@ restore.resource.success=Versão \#{0} do recurso {1} restaurada após a falha d
 restore.resource.failed=A restauração da versão \#{0} do recurso {1} falhou\: {2}
 
 # Auto-publishing
-autopublish=Auto-publicação
-autopublish.off=Desativar
-autopublish.update=Publicar & modificar intervalo de auto-publicação
-autopublish.activate=Publicar & ativar auto-publicação
-autopublish.disable=Publicar & desativar auto-publicação
-autopublish.interval=Selecionar intervalo
-autopublish.help=Para <strong>ativar</strong> a publicação automática, selecione uma das 5 opções de intervalos de publicação e clique em publicar. Para <strong>alterar</strong> o intervalo de publicação, selecione uma opção diferente de intervalo de publicação e clique em publicar. Para <strong>desativar</strong> a publicação automática, selecione "Desativar" e clique em publicar.
+
+manage.overview.autopublish.title=Auto-publicação
+manage.overview.autopublish.description=You can activate auto-publishing here and define the publication schedule for this resource (frequency and additionnal information)
+manage.overview.autopublish.intro.activated=Auto-publish is activated. Your resource will be automatically published as scheduled below.
+manage.overview.autopublish.intro.deactivated=Auto-publish is deactivated. Your resource should be published manually with the Publish button.
+manage.overview.autopublish.deprecated.warning.button=The configuration is deprecated. Please update it.
+manage.overview.autopublish.deprecated.warning.description=<strong>This configuration is deprecated</strong>. Please update it.
+manage.overview.autopublish.publication.frequency=Frequency
+manage.overview.autopublish.publication.next.date=Next publication date
+
+manage.autopublish.title=Auto-publicação
+manage.autopublish.intro=Please select one of the <strong>5 publishing intervals</strong> to activate the auto-publishing.<br/>Fill in the additional frequency information and press Save.<br/><br/>To <strong>turn off</strong> the auto-publishing, select "Turn off" in the list and press Save<br/>(this will not generate a new version of the resource).
+manage.autopublish.intro.annually=This resource will be published automatically once a year.
+manage.autopublish.intro.biannually=This resource will be published automatically twice a year.
+manage.autopublish.intro.monthly=This resource will be published automatically every month.
+manage.autopublish.intro.weekly=This resource will be published automatically every week.
+manage.autopublish.intro.daily=This resource will be published automatically every day.
+manage.autopublish.intro.off=This resource will be published manually.
+
+manage.autopublish.help.annually=<strong>month</strong> and <strong>day of month</strong>
+manage.autopublish.help.biannually=<strong>two months</strong> and <strong>day of month</strong>
+manage.autopublish.help.monthly=<strong>day of month</strong>
+manage.autopublish.help.weekly=<strong>day of week</strong>
+manage.autopublish.help.hour=<strong>hours</strong> and <strong>minutes</strong> (related to your IPT server timezone)
+
+manage.autopublish.frequency=Auto-publishing frequency
+manage.autopublish.off=Desativar
+manage.autopublish.january=January
+manage.autopublish.february=February
+manage.autopublish.march=March
+manage.autopublish.april=April
+manage.autopublish.may=May
+manage.autopublish.june=June
+manage.autopublish.july=July
+manage.autopublish.august=August
+manage.autopublish.september=September
+manage.autopublish.october=October
+manage.autopublish.november=November
+manage.autopublish.december=December
+manage.autopublish.monday=Monday
+manage.autopublish.tuesday=Tuesday
+manage.autopublish.wednesday=Wednesday
+manage.autopublish.thursday=Thursday
+manage.autopublish.friday=Friday
+manage.autopublish.saturday=Saturday
+manage.autopublish.sunday=Sunday
+manage.autopublish.january_july=January/July
+manage.autopublish.february_august=February/August
+manage.autopublish.march_september=March/September
+manage.autopublish.april_october=April/October
+manage.autopublish.may_november=May/November
+manage.autopublish.june_december=June/December
 
 # Struts2 overrides
 struts.messages.upload.error.SizeLimitExceededException=O arquivo enviado é muito grande\! Tamanho máximo permitido é de {0} bytes, mas requisitado foi {1} bytes. Para contornar esse problema, você pode tentar compactar o arquivo (com zip ou gzip), carregar os dados em um dos muitos bancos de dados suportados pelo IPT ou dividir o arquivo. Por favor consulte o manual do usuário para obter mais informações.

--- a/src/main/resources/ApplicationResources_ru.properties
+++ b/src/main/resources/ApplicationResources_ru.properties
@@ -1428,13 +1428,58 @@ restore.resource.success=Восстановленная версия \#{0} ре�
 restore.resource.failed=При восстановлении версии \#{0} ресурса {1} возникла ошибка\: {2}
 
 # Auto-publishing
-autopublish=Автоматическая публикация
-autopublish.off=Отключить
-autopublish.update=Опубликовать и изменить интервал автоматической публикации
-autopublish.activate=Опубликовать и включить автопубликацию
-autopublish.disable=Опубликовать и отключить автопубликацию
-autopublish.interval=Выберите интервал
-autopublish.help=Для того, чтобы <strong>включить</strong> автоматическую публикацию выберите один из 5 временных интервалов и затем нажмите "Опубликовать". Чтобы <strong>изменить</strong> интервал автоматической публикации выберите другой интервал публикации и нажмите "Опубликовать". Для <strong>отключения</strong> автоматической публикации, выберите «Выключить», а затем нажмите "Опубликовать".
+
+manage.overview.autopublish.title=Автоматическая публикация
+manage.overview.autopublish.description=You can activate auto-publishing here and define the publication schedule for this resource (frequency and additionnal information)
+manage.overview.autopublish.intro.activated=Auto-publish is activated. Your resource will be automatically published as scheduled below.
+manage.overview.autopublish.intro.deactivated=Auto-publish is deactivated. Your resource should be published manually with the Publish button.
+manage.overview.autopublish.deprecated.warning.button=The configuration is deprecated. Please update it.
+manage.overview.autopublish.deprecated.warning.description=<strong>This configuration is deprecated</strong>. Please update it.
+manage.overview.autopublish.publication.frequency=Frequency
+manage.overview.autopublish.publication.next.date=Next publication date
+
+manage.autopublish.title=Автоматическая публикация
+manage.autopublish.intro=Please select one of the <strong>5 publishing intervals</strong> to activate the auto-publishing.<br/>Fill in the additional frequency information and press Save.<br/><br/>To <strong>turn off</strong> the auto-publishing, select "Turn off" in the list and press Save<br/>(this will not generate a new version of the resource).
+manage.autopublish.intro.annually=This resource will be published automatically once a year.
+manage.autopublish.intro.biannually=This resource will be published automatically twice a year.
+manage.autopublish.intro.monthly=This resource will be published automatically every month.
+manage.autopublish.intro.weekly=This resource will be published automatically every week.
+manage.autopublish.intro.daily=This resource will be published automatically every day.
+manage.autopublish.intro.off=This resource will be published manually.
+
+manage.autopublish.help.annually=<strong>month</strong> and <strong>day of month</strong>
+manage.autopublish.help.biannually=<strong>two months</strong> and <strong>day of month</strong>
+manage.autopublish.help.monthly=<strong>day of month</strong>
+manage.autopublish.help.weekly=<strong>day of week</strong>
+manage.autopublish.help.hour=<strong>hours</strong> and <strong>minutes</strong> (related to your IPT server timezone)
+
+manage.autopublish.frequency=Auto-publishing frequency
+manage.autopublish.off=Отключить
+manage.autopublish.january=January
+manage.autopublish.february=February
+manage.autopublish.march=March
+manage.autopublish.april=April
+manage.autopublish.may=May
+manage.autopublish.june=June
+manage.autopublish.july=July
+manage.autopublish.august=August
+manage.autopublish.september=September
+manage.autopublish.october=October
+manage.autopublish.november=November
+manage.autopublish.december=December
+manage.autopublish.monday=Monday
+manage.autopublish.tuesday=Tuesday
+manage.autopublish.wednesday=Wednesday
+manage.autopublish.thursday=Thursday
+manage.autopublish.friday=Friday
+manage.autopublish.saturday=Saturday
+manage.autopublish.sunday=Sunday
+manage.autopublish.january_july=January/July
+manage.autopublish.february_august=February/August
+manage.autopublish.march_september=March/September
+manage.autopublish.april_october=April/October
+manage.autopublish.may_november=May/November
+manage.autopublish.june_december=June/December
 
 # Struts2 overrides
 struts.messages.upload.error.SizeLimitExceededException=Загруженный файл слишком велик\! Максимальный размер составляет {0} байт, но было запрошено {1} байт. Чтобы обойти эту проблему, вы можете попробовать сжать файл (в формат zip или gzip), загрузить данные в одну из многочисленных баз данных, поддерживаемых IPT или разделить файл на части. Пожалуйста, обратитесь к руководству пользователя для получения дополнительной информации.

--- a/src/main/resources/ApplicationResources_tr.properties
+++ b/src/main/resources/ApplicationResources_tr.properties
@@ -1427,13 +1427,58 @@ restore.resource.success=Restored version \#{0} of resource {1} after publishing
 restore.resource.failed=Restoring version \#{0} of resource {1} failed\: {2}
 
 # Auto-publishing
-autopublish=Auto-publishing
-autopublish.off=Turn off
-autopublish.update=Publish & change auto-publishing interval
-autopublish.activate=Publish & turn on auto-publishing
-autopublish.disable=Publish & turn off auto-publishing
-autopublish.interval=Select interval
-autopublish.help=To <strong>turn on</strong> automated publishing, select one of the 5 publishing intervals and then press publish. To <strong>change</strong> the automated publishing interval, select a different publishing interval and press publish. To <strong>turn off</strong> automated publishing, select "Turn off" and then press publish.
+
+manage.overview.autopublish.title=Auto-publishing
+manage.overview.autopublish.description=You can activate auto-publishing here and define the publication schedule for this resource (frequency and additionnal information)
+manage.overview.autopublish.intro.activated=Auto-publish is activated. Your resource will be automatically published as scheduled below.
+manage.overview.autopublish.intro.deactivated=Auto-publish is deactivated. Your resource should be published manually with the Publish button.
+manage.overview.autopublish.deprecated.warning.button=The configuration is deprecated. Please update it.
+manage.overview.autopublish.deprecated.warning.description=<strong>This configuration is deprecated</strong>. Please update it.
+manage.overview.autopublish.publication.frequency=Frequency
+manage.overview.autopublish.publication.next.date=Next publication date
+
+manage.autopublish.title=Auto-publishing
+manage.autopublish.intro=Please select one of the <strong>5 publishing intervals</strong> to activate the auto-publishing.<br/>Fill in the additional frequency information and press Save.<br/><br/>To <strong>turn off</strong> the auto-publishing, select "Turn off" in the list and press Save<br/>(this will not generate a new version of the resource).
+manage.autopublish.intro.annually=This resource will be published automatically once a year.
+manage.autopublish.intro.biannually=This resource will be published automatically twice a year.
+manage.autopublish.intro.monthly=This resource will be published automatically every month.
+manage.autopublish.intro.weekly=This resource will be published automatically every week.
+manage.autopublish.intro.daily=This resource will be published automatically every day.
+manage.autopublish.intro.off=This resource will be published manually.
+
+manage.autopublish.help.annually=<strong>month</strong> and <strong>day of month</strong>
+manage.autopublish.help.biannually=<strong>two months</strong> and <strong>day of month</strong>
+manage.autopublish.help.monthly=<strong>day of month</strong>
+manage.autopublish.help.weekly=<strong>day of week</strong>
+manage.autopublish.help.hour=<strong>hours</strong> and <strong>minutes</strong> (related to your IPT server timezone)
+
+manage.autopublish.frequency=Auto-publishing frequency
+manage.autopublish.off=Turn off
+manage.autopublish.january=January
+manage.autopublish.february=February
+manage.autopublish.march=March
+manage.autopublish.april=April
+manage.autopublish.may=May
+manage.autopublish.june=June
+manage.autopublish.july=July
+manage.autopublish.august=August
+manage.autopublish.september=September
+manage.autopublish.october=October
+manage.autopublish.november=November
+manage.autopublish.december=December
+manage.autopublish.monday=Monday
+manage.autopublish.tuesday=Tuesday
+manage.autopublish.wednesday=Wednesday
+manage.autopublish.thursday=Thursday
+manage.autopublish.friday=Friday
+manage.autopublish.saturday=Saturday
+manage.autopublish.sunday=Sunday
+manage.autopublish.january_july=January/July
+manage.autopublish.february_august=February/August
+manage.autopublish.march_september=March/September
+manage.autopublish.april_october=April/October
+manage.autopublish.may_november=May/November
+manage.autopublish.june_december=June/December
 
 # Struts2 overrides
 struts.messages.upload.error.SizeLimitExceededException=The uploaded file is too large\! Max size allowed is {0} bytes but request was {1} bytes. To work around this problem, you can try compressing the file (with zip or gzip), loading the data into one of the many databases supported by the IPT, or splitting the file up. Please refer to the user manual for more information.

--- a/src/main/resources/ApplicationResources_zh.properties
+++ b/src/main/resources/ApplicationResources_zh.properties
@@ -1428,13 +1428,58 @@ restore.resource.success=由於發布失敗，還原資料集 {1} 至版本 \#{0
 restore.resource.failed=還原資料集 {1} 版本 \#{0} 失敗：{2}
 
 # Auto-publishing
-autopublish=自動定期發布
-autopublish.off=關閉
-autopublish.update=改變發布週期並發布
-autopublish.activate=發布並開啟自動定期發布
-autopublish.disable=發布並關閉自動定期發布
-autopublish.interval=選擇發布週期
-autopublish.help=欲 <strong>開啟</strong> 自動定期發布，請選擇一發布週期（共有五個選項）後點選發布。欲 <strong>改變</strong> 自動定期發布之週期，選擇一新選項後點選發布。欲 <strong>關閉</strong> 自動定期更新，選擇「關閉」後點選發布。
+
+manage.overview.autopublish.title=自動定期發布
+manage.overview.autopublish.description=You can activate auto-publishing here and define the publication schedule for this resource (frequency and additionnal information)
+manage.overview.autopublish.intro.activated=Auto-publish is activated. Your resource will be automatically published as scheduled below.
+manage.overview.autopublish.intro.deactivated=Auto-publish is deactivated. Your resource should be published manually with the Publish button.
+manage.overview.autopublish.deprecated.warning.button=The configuration is deprecated. Please update it.
+manage.overview.autopublish.deprecated.warning.description=<strong>This configuration is deprecated</strong>. Please update it.
+manage.overview.autopublish.publication.frequency=Frequency
+manage.overview.autopublish.publication.next.date=Next publication date
+
+manage.autopublish.title=自動定期發布
+manage.autopublish.intro=Please select one of the <strong>5 publishing intervals</strong> to activate the auto-publishing.<br/>Fill in the additional frequency information and press Save.<br/><br/>To <strong>turn off</strong> the auto-publishing, select "Turn off" in the list and press Save<br/>(this will not generate a new version of the resource).
+manage.autopublish.intro.annually=This resource will be published automatically once a year.
+manage.autopublish.intro.biannually=This resource will be published automatically twice a year.
+manage.autopublish.intro.monthly=This resource will be published automatically every month.
+manage.autopublish.intro.weekly=This resource will be published automatically every week.
+manage.autopublish.intro.daily=This resource will be published automatically every day.
+manage.autopublish.intro.off=This resource will be published manually.
+
+manage.autopublish.help.annually=<strong>month</strong> and <strong>day of month</strong>
+manage.autopublish.help.biannually=<strong>two months</strong> and <strong>day of month</strong>
+manage.autopublish.help.monthly=<strong>day of month</strong>
+manage.autopublish.help.weekly=<strong>day of week</strong>
+manage.autopublish.help.hour=<strong>hours</strong> and <strong>minutes</strong> (related to your IPT server timezone)
+
+manage.autopublish.frequency=Auto-publishing frequency
+manage.autopublish.off=關閉
+manage.autopublish.january=January
+manage.autopublish.february=February
+manage.autopublish.march=March
+manage.autopublish.april=April
+manage.autopublish.may=May
+manage.autopublish.june=June
+manage.autopublish.july=July
+manage.autopublish.august=August
+manage.autopublish.september=September
+manage.autopublish.october=October
+manage.autopublish.november=November
+manage.autopublish.december=December
+manage.autopublish.monday=Monday
+manage.autopublish.tuesday=Tuesday
+manage.autopublish.wednesday=Wednesday
+manage.autopublish.thursday=Thursday
+manage.autopublish.friday=Friday
+manage.autopublish.saturday=Saturday
+manage.autopublish.sunday=Sunday
+manage.autopublish.january_july=January/July
+manage.autopublish.february_august=February/August
+manage.autopublish.march_september=March/September
+manage.autopublish.april_october=April/October
+manage.autopublish.may_november=May/November
+manage.autopublish.june_december=June/December
 
 # Struts2 overrides
 struts.messages.upload.error.SizeLimitExceededException=The uploaded file is too large\! Max size allowed is {0} bytes but request was {1} bytes. To work around this problem, you can try compressing the file (with zip or gzip), loading the data into one of the many databases supported by the IPT, or splitting the file up. Please refer to the user manual for more information.

--- a/src/main/resources/struts-manage.xml
+++ b/src/main/resources/struts-manage.xml
@@ -64,6 +64,12 @@
       <allowed-methods>addManager,delete,deleteDoi,deleteManager,makePrivate,makePublic,registerResource,reserveDoi,undelete</allowed-methods>
     </action>
 
+    <action name="auto-publish" class="org.gbif.ipt.action.manage.AutoPublishAction">
+      <result name="input">/WEB-INF/pages/manage/autopublish.ftl</result>
+      <result name="success" type="redirect">${baseURL}/manage/resource.do?r=${resource.shortname}</result>
+      <result name="error" type="redirect">${baseURL}/manage/resource.do?r=${resource.shortname}</result>
+    </action>
+
     <!-- EML metadata actions dynamically invoked. This is the *only* action needed for all forms -->
     <action name="metadata-*" class="org.gbif.ipt.action.manage.MetadataAction">
       <!-- Setting parameters like this doesn't seem to work as expected :((( -->

--- a/src/main/webapp/WEB-INF/pages/macros/manage/publish.ftl
+++ b/src/main/webapp/WEB-INF/pages/macros/manage/publish.ftl
@@ -2,21 +2,6 @@
 <form action='publish.do' method='post'>
   <input name="r" type="hidden" value="${resource.shortname}"/>
 
-  <#-- Auto-publishing mode-->
-  <#assign puMo="">
-    <#if resource.publicationMode??>
-    <#assign puMo=resource.publicationMode>
-  </#if>
-  <input id="currPubMode" name="currPubMode" type="hidden" value="${puMo}"/>
-  <input id="pubMode" name="pubMode" type="hidden" value=""/>
-
-  <#-- Auto-publishing frequency-->
-  <#assign upFr="">
-  <#if resource.updateFrequency??>
-    <#assign upFr=resource.updateFrequency.identifier>
-  </#if>
-  <input id="currPubFreq" name="currPubFreq" type="hidden" value="${upFr}"/>
-  <input id="pubFreq" name="pubFreq" type="hidden" value=""/>
   <textarea id="summary" name="summary" cols="40" rows="5" style="display: none"></textarea>
 
   <!-- resources cannot be published if the mandatory metadata is missing -->
@@ -97,19 +82,5 @@
 
   <br/>
   <br/>
-  <div id="actions" class="autop">
-      <label for="autopublish"><@s.text name="autopublish"/></label>
-      <select id="autopublish" name="autopublish" size="1">
-        <#list frequencies?keys as val>
-            <option value="${val}" <#if (upFr!"")==val> selected="selected"</#if>>
-              <@s.text name="${frequencies.get(val)}"/>
-            </option>
-        </#list>
-      </select>
-      <img class="infoImg" src="${baseURL}/images/info.gif" />
-      <div class="info">
-        <@s.text name="autopublish.help"/>
-      </div>
-  </div>
 </form>
 </#macro>

--- a/src/main/webapp/WEB-INF/pages/manage/autopublish.ftl
+++ b/src/main/webapp/WEB-INF/pages/manage/autopublish.ftl
@@ -1,0 +1,242 @@
+<#escape x as x?html>
+    <#include "/WEB-INF/pages/inc/header.ftl">
+    <title><@s.text name='manage.autopublish.title'/></title>
+
+    <#assign currentMenu = "manage"/>
+    <#include "/WEB-INF/pages/inc/menu.ftl">
+    <#include "/WEB-INF/pages/macros/forms.ftl"/>
+
+    <script>
+        $(document).ready(function() {
+            initHelp();
+
+            // on select of publishing frequency set parameters for publishing frequency
+            $('#updateFrequency').change(function () {
+                var str = "";
+                $("#updateFrequency option:selected").each(function () {
+                    str += $(this).val();
+                });
+
+                $('#introAnnually').hide();
+                $('#introBiAnnually').hide();
+                $('#introMonthly').hide();
+                $('#introWeekly').hide();
+                $('#introDaily').hide();
+                $('#introOff').hide();
+                $('#helpAnnually').hide();
+                $('#helpBiAnnually').hide();
+                $('#helpMonthly').hide();
+                $('#helpWeekly').hide();
+                $('#frequencyDetailsEvery').hide();
+                $('#frequencyDetailsAt').hide();
+                $('#updateFrequencyMonth').hide();
+                $('#updateFrequencyBiMonth').hide();
+                $('#updateFrequencyDay').hide();
+                $('#updateFrequencyDayOfWeek').hide();
+                if (str == "annually") {
+                    $('#introAnnually').show();
+                    $('#helpAnnually').show();
+                    $('#frequencyDetailsEvery').show();
+                    $('#updateFrequencyMonth').show();
+                    $('#updateFrequencyDay').show();
+                    $('#frequencyDetailsAt').show();
+                } else if (str == "biannually") {
+                    $('#introBiAnnually').show();
+                    $('#helpBiAnnually').show();
+                    $('#frequencyDetailsEvery').show();
+                    $('#updateFrequencyBiMonth').show();
+                    $('#updateFrequencyDay').show();
+                    $('#frequencyDetailsAt').show();
+                } else if (str == "monthly") {
+                    $('#introMonthly').show();
+                    $('#helpMonthly').show();
+                    $('#frequencyDetailsEvery').show();
+                    $('#updateFrequencyDay').show();
+                    $('#frequencyDetailsAt').show();
+                } else if (str == "weekly") {
+                    $('#introWeekly').show();
+                    $('#helpWeekly').show();
+                    $('#frequencyDetailsEvery').show();
+                    $('#updateFrequencyDayOfWeek').show();
+                    $('#frequencyDetailsAt').show();
+                } else if (str == "daily") {
+                    $('#introDaily').show();
+                    $('#frequencyDetailsAt').show();
+                } else {
+                    $('#introOff').show();
+                }
+
+            }).change();
+
+        });
+
+    </script>
+
+    <div class="grid_17 suffix_7">
+        <form class="topForm" action="auto-publish.do" method="post">
+            <h1><@s.text name='manage.autopublish.title'/></h1>
+            <p><@s.text name='manage.autopublish.intro'/></p>
+            <#if resource.isDeprecatedAutoPublishingConfiguration()>
+                <ul class="fielderror">
+                    <li><span><@s.text name='manage.overview.autopublish.deprecated.warning.description'/></span></li>
+                </ul>
+                <br/>
+            </#if>
+            <input type="hidden" name="r" value="${resource.shortname}" />
+
+            <#-- Auto-publishing frequency-->
+            <#assign updateFrequency="">
+            <#if resource.updateFrequency??>
+                <#assign updateFrequency=resource.updateFrequency.identifier>
+            </#if>
+            <#-- Auto-publishing month-->
+            <#assign updateFrequencyMonth="">
+            <#if resource.updateFrequencyMonth??>
+                <#assign updateFrequencyMonth=resource.updateFrequencyMonth.identifier>
+            </#if>
+            <#-- Auto-publishing biMonth-->
+            <#assign updateFrequencyBiMonth="">
+            <#if resource.updateFrequencyBiMonth??>
+                <#assign updateFrequencyBiMonth=resource.updateFrequencyBiMonth.identifier>
+            </#if>
+            <#-- Auto-publishing day-->
+            <#assign updateFrequencyDay="">
+            <#if resource.updateFrequencyDay??>
+                <#assign updateFrequencyDay=resource.updateFrequencyDay>
+            </#if>
+            <#-- Auto-publishing dayOfWeek-->
+            <#assign updateFrequencyDayOfWeek="">
+            <#if resource.updateFrequencyDayOfWeek??>
+                <#assign updateFrequencyDayOfWeek=resource.updateFrequencyDayOfWeek.identifier>
+            </#if>
+            <#-- Auto-publishing hour-->
+            <#assign updateFrequencyHour="">
+            <#if resource.updateFrequencyHour??>
+                <#assign updateFrequencyHour=resource.updateFrequencyHour>
+            </#if>
+            <#-- Auto-publishing minute-->
+            <#assign updateFrequencyMinute="">
+            <#if resource.updateFrequencyMinute??>
+                <#assign updateFrequencyMinute=resource.updateFrequencyMinute>
+            </#if>
+
+            <div>
+                <label for="updateFrequency"><@s.text name="manage.autopublish.frequency"/></label>
+                <select id="updateFrequency" name="updateFrequency" size="1">
+                    <#list frequencies?keys as val>
+                        <option value="${val}" <#if (updateFrequency!"")==val> selected="selected"</#if>>
+                            <@s.text name="${frequencies.get(val)}"/>
+                        </option>
+                    </#list>
+                </select>
+            </div>
+
+            <p id="introAnnually">
+                <br/>
+                <@s.text name="manage.autopublish.intro.annually"/>
+            </p>
+            <p id="introBiAnnually">
+                <br/>
+                <@s.text name="manage.autopublish.intro.biannually"/>
+            </p>
+            <p id="introMonthly">
+                <br/>
+                <@s.text name="manage.autopublish.intro.monthly"/>
+            </p>
+            <p id="introWeekly">
+                <br/>
+                <@s.text name="manage.autopublish.intro.weekly"/>
+            </p>
+            <p id="introDaily">
+                <br/>
+                <@s.text name="manage.autopublish.intro.daily"/>
+            </p>
+            <p id="introOff">
+                <br/>
+                <@s.text name="manage.autopublish.intro.off"/>
+            </p>
+
+            <div id="frequencyDetails" class="autop">
+                <div id="frequencyDetailsEvery">
+                    <div>
+                        <label>Every</label>
+                    </div>
+                    <div>
+                        <select id="updateFrequencyMonth" name="updateFrequencyMonth" size="1">
+                            <#list months?keys as val>
+                                <option value="${val}" <#if (updateFrequencyMonth!"")==val> selected="selected"</#if>>
+                                    <@s.text name="${months.get(val)}"/>
+                                </option>
+                            </#list>
+                        </select>
+                        <select id="updateFrequencyBiMonth" name="updateFrequencyBiMonth" size="1">
+                            <#list biMonths?keys as val>
+                                <option value="${val}" <#if (updateFrequencyBiMonth!"")==val> selected="selected"</#if>>
+                                    <@s.text name="${biMonths.get(val)}"/>
+                                </option>
+                            </#list>
+                        </select>
+                        <select id="updateFrequencyDay" name="updateFrequencyDay" size="1">
+                            <#list days?keys as val>
+                                <option value="${val}" <#if (updateFrequencyDay!"")?string==val?string> selected="selected"</#if>>
+                                    <@s.text name="${days.get(val)}"/>
+                                </option>
+                            </#list>
+                        </select>
+                        <select id="updateFrequencyDayOfWeek" name="updateFrequencyDayOfWeek" size="1">
+                            <#list daysOfWeek?keys as val>
+                                <option value="${val}" <#if (updateFrequencyDayOfWeek!"")==val> selected="selected"</#if>>
+                                    <@s.text name="${daysOfWeek.get(val)}"/>
+                                </option>
+                            </#list>
+                        </select>
+                        <img class="infoImg" src="${baseURL}/images/info.gif" />
+                        <div class="info">
+                            <span id="helpAnnually"><@s.text name="manage.autopublish.help.annually"/></span>
+                            <span id="helpBiAnnually"><@s.text name="manage.autopublish.help.biannually"/></span>
+                            <span id="helpMonthly"><@s.text name="manage.autopublish.help.monthly"/></span>
+                            <span id="helpWeekly"><@s.text name="manage.autopublish.help.weekly"/></span>
+                        </div>
+                    </div>
+                </div>
+                <div id="frequencyDetailsAt">
+                    <div>
+                        <label>At</label>
+                    </div>
+                    <div>
+                        <select id="updateFrequencyHour" name="updateFrequencyHour" size="1">
+                            <#list hours?keys as val>
+                                <option value="${val}" <#if (updateFrequencyHour!"")?string==val?string> selected="selected"</#if>>
+                                    <@s.text name="${hours.get(val)}"/>
+                                </option>
+                            </#list>
+                        </select>
+                        h
+                        <select id="updateFrequencyMinute" name="updateFrequencyMinute" size="1">
+                            <#list minutes?keys as val>
+                                <option value="${val}" <#if (updateFrequencyMinute!"")?string==val?string> selected="selected"</#if>>
+                                    <@s.text name="${minutes.get(val)}"/>
+                                </option>
+                            </#list>
+                        </select>
+                        <img class="infoImg" src="${baseURL}/images/info.gif" />
+                        <div class="info">
+                            <@s.text name="manage.autopublish.help.hour"/>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <br/>
+            <br/>
+
+            <div class="buttons">
+                <@s.submit cssClass="button" name="save" value="save" key="button.save"/>
+                <@s.submit cssClass="button" name="cancel" value="cancel" key="button.cancel"/>
+            </div>
+
+        </form>
+    </div>
+
+    <#include "/WEB-INF/pages/inc/footer.ftl">
+</#escape>

--- a/src/main/webapp/WEB-INF/pages/manage/overview.ftl
+++ b/src/main/webapp/WEB-INF/pages/manage/overview.ftl
@@ -91,7 +91,7 @@ $(document).ready(function(){
   initHelp();
 	<#if confirmOverwrite>
 		showConfirmOverwrite();
-	</#if>	
+	</#if>
 	var $registered = false;
 
 	$('.confirm').jConfirmAction({question : "<@s.text name='basic.confirm'/>", yesAnswer : "<@s.text name='basic.yes'/>", cancelAnswer : "<@s.text name='basic.no'/>"});
@@ -122,7 +122,7 @@ $(document).ready(function(){
 		$(this).click(function() {
 			window.location = $(this).parent('a').attr('href');
 		});
-	});	
+	});
 	$('.submit').each(function() {
 		$(this).click(function() {
 			$(this).parent('form').submit();
@@ -130,7 +130,7 @@ $(document).ready(function(){
 	});
 	$("#file").change(function() {
 		var usedFileName = $("#file").prop("value");
-		if(usedFileName != "") {			
+		if(usedFileName != "") {
 			$("#add").attr("value", '<@s.text name="button.add"/>');
 		}
 	});
@@ -144,43 +144,6 @@ $(document).ready(function(){
     $('.icon-validate').tooltip({track: true});
   });
 
-    // on select of publishing frequency set parameter for publishing frequency
-    $('#autopublish').change(function () {
-        var str = "";
-        $("#autopublish option:selected").each(function () {
-            str += $(this).val();
-        });
-        // set selected frequency
-        $("#pubFreq").val(str);
-
-        // gather current publishing frequency
-        var currFreq = $("#currPubFreq").val();
-
-        // gather current auto-publishing mode
-        var currMode = $("#currPubMode").val();
-
-        // when auto-publishing is off, and a frequency is selected
-        if (currMode=="AUTO_PUBLISH_OFF" && currMode !="" && str!="") {
-            $('#publishButton').val("<@s.text name='autopublish.activate'/>");
-            $("#pubMode").val("AUTO_PUBLISH_ON");
-        }
-        // when auto-publishing is on, and the user wants to disable auto-publishing
-        else if(currMode=="AUTO_PUBLISH_ON" && str=="off") {
-            $('#publishButton').val("<@s.text name='autopublish.disable'/>");
-            $("#pubMode").val("AUTO_PUBLISH_OFF");
-        }
-        // when auto-publishing is on, and the user wants to change the frequency
-        else if(currMode=="AUTO_PUBLISH_ON" && currFreq!=str) {
-            $('#publishButton').val("<@s.text name='autopublish.update'/>");
-            $("#pubMode").val("AUTO_PUBLISH_ON");
-        }
-        // when either auto-publishing is on, and the user is happy with the current settings,
-        // or when auto-publishing is off and no frequency selected
-        else {
-            $('#publishButton').val("<@s.text name='button.publish'/>");
-        }
-    }).change();
-
 	function showConfirmOverwrite() {
 	   var question='<p><@s.text name="manage.resource.addSource.confirm"/></p>';
 	   $('#dialog').html(question);
@@ -192,7 +155,7 @@ $(document).ready(function(){
 					$(this).dialog("close");
 					$("#add").click();
 				},
-				'<@s.text name="basic.no"/>' : function(){					
+				'<@s.text name="basic.no"/>' : function(){
 					$(this).dialog("close");
 					$("#cancel").click();
 				}
@@ -371,6 +334,57 @@ $(document).ready(function(){
       </div>
   </div>
 </div>
+
+    <div class="resourceOverview" id="autopublish">
+        <div class="titleOverview">
+            <div class="head">
+                <img class="infoImg" src="${baseURL}/images/info.gif" />
+                <div class="info autop">
+                    <@s.text name="manage.overview.autopublish.description"/>
+                </div>
+                <@s.text name="manage.overview.autopublish.title"/>
+            </div>
+            <div class="actions">
+                <form action='auto-publish.do' method='get'>
+                    <input name="r" type="hidden" value="${resource.shortname}"/>
+                    <#if resource.isDeprecatedAutoPublishingConfiguration()>
+                        <@s.submit name="edit" key="button.edit"/>
+                        <img class="infoImg" src="${baseURL}/images/warning.gif"/>
+                        <div class="info autop">
+                            <@s.text name="manage.overview.autopublish.deprecated.warning.button"/>
+                        </div>
+                    <#else>
+                        <@s.submit name="edit" key="button.edit"/>
+                    </#if>
+                </form>
+            </div>
+        </div>
+        <div class="bodyOverview">
+
+            <p>
+                <#if resource.usesAutoPublishing()>
+                    <@s.text name="manage.overview.autopublish.intro.activated"/>
+                <#else>
+                    <@s.text name="manage.overview.autopublish.intro.deactivated"/>
+                </#if>
+            </p>
+
+            <div class="details">
+                <table>
+                    <#if resource.usesAutoPublishing()>
+                    <tr>
+                        <th><@s.text name='manage.overview.autopublish.publication.frequency'/></th>
+                        <td><@s.text name="${autoPublishFrequencies.get(resource.updateFrequency.identifier)}"/></td>
+                    </tr>
+                    <tr>
+                        <th><@s.text name='manage.overview.autopublish.publication.next.date'/></th>
+                        <td>${resource.nextPublished?date?string("MMM d, yyyy, HH:mm:ss")}</td>
+                    </tr>
+                    </#if>
+                </table>
+            </div>
+        </div>
+    </div>
 
 <div class="resourceOverview" id="visibility">
   <div class="titleOverview">

--- a/src/test/java/org/gbif/ipt/action/manage/OverviewActionIT.java
+++ b/src/test/java/org/gbif/ipt/action/manage/OverviewActionIT.java
@@ -134,7 +134,7 @@ public class OverviewActionIT {
     OverviewAction actionDataCite =
         new OverviewAction(mock(SimpleTextProvider.class), mockAppConfig, mockRegistrationManagerDataCite,
             mock(ResourceManager.class), mock(UserAccountManager.class), mock(ExtensionManager.class),
-            mock(VocabulariesManager.class), mock(GenerateDwcaFactory.class));
+            mock(GenerateDwcaFactory.class), mock(VocabulariesManager.class));
 
     return new Object[][]{
         {actionDataCite, DOIRegistrationAgency.DATACITE}

--- a/src/test/java/org/gbif/ipt/action/manage/OverviewActionOtherIT.java
+++ b/src/test/java/org/gbif/ipt/action/manage/OverviewActionOtherIT.java
@@ -153,8 +153,8 @@ public class OverviewActionOtherIT {
         mock(ResourceManager.class),
         mock(UserAccountManager.class),
         mock(ExtensionManager.class),
-        mock(VocabulariesManager.class),
-        mock(GenerateDwcaFactory.class));
+        mock(GenerateDwcaFactory.class),
+        mock(VocabulariesManager.class));
 
     LOG.info("Testing DataCite with GBIF test Prefix...");
     action.setReserveDoi("true");
@@ -224,8 +224,8 @@ public class OverviewActionOtherIT {
         mock(ResourceManager.class),
         mock(UserAccountManager.class),
         mock(ExtensionManager.class),
-        mock(VocabulariesManager.class),
-        mock(GenerateDwcaFactory.class));
+        mock(GenerateDwcaFactory.class),
+        mock(VocabulariesManager.class));
 
     LOG.info("Testing DataCite with GBIF test Prefix...");
     action.setReserveDoi("true");
@@ -294,8 +294,8 @@ public class OverviewActionOtherIT {
         mock(ResourceManager.class),
         mock(UserAccountManager.class),
         mock(ExtensionManager.class),
-        mock(VocabulariesManager.class),
-        mock(GenerateDwcaFactory.class));
+        mock(GenerateDwcaFactory.class),
+        mock(VocabulariesManager.class));
 
     LOG.info("Testing DataCite with GBIF test Prefix...");
     action.setReserveDoi("true");
@@ -361,8 +361,8 @@ public class OverviewActionOtherIT {
         mock(ResourceManager.class),
         mock(UserAccountManager.class),
         mock(ExtensionManager.class),
-        mock(VocabulariesManager.class),
-        mock(GenerateDwcaFactory.class));
+        mock(GenerateDwcaFactory.class),
+        mock(VocabulariesManager.class));
 
     LOG.info("Testing DataCite with test Prefix...");
     action.setDeleteDoi("true");

--- a/src/test/java/org/gbif/ipt/action/manage/OverviewActionTest.java
+++ b/src/test/java/org/gbif/ipt/action/manage/OverviewActionTest.java
@@ -74,8 +74,7 @@ public class OverviewActionTest {
     // mock action
     action =
       new OverviewAction(mock(SimpleTextProvider.class), mockCfg, mock(RegistrationManager.class), mockResourceManager,
-        mock(UserAccountManager.class), mock(ExtensionManager.class), mock(VocabulariesManager.class),
-        mock(GenerateDwcaFactory.class));
+        mock(UserAccountManager.class), mock(ExtensionManager.class), mock(GenerateDwcaFactory.class), mock(VocabulariesManager.class));
   }
 
   @Test
@@ -306,8 +305,8 @@ public class OverviewActionTest {
     when(mockRegistrationManager.getDoiService()).thenReturn(mockDataCiteService);
     // mock action
     action = new OverviewAction(mock(SimpleTextProvider.class), mock(AppConfig.class), mockRegistrationManager,
-      mock(ResourceManager.class), mock(UserAccountManager.class), mock(ExtensionManager.class),
-      mock(VocabulariesManager.class), mock(GenerateDwcaFactory.class));
+      mock(ResourceManager.class), mock(UserAccountManager.class), mock(ExtensionManager.class), mock(GenerateDwcaFactory.class),
+            mock(VocabulariesManager.class));
     action.setResource(r);
     action.setUndelete("true");
     assertEquals("input", action.undelete());
@@ -346,8 +345,8 @@ public class OverviewActionTest {
 
     // mock action
     action = new OverviewAction(mock(SimpleTextProvider.class), mock(AppConfig.class), mockRegistrationManager,
-      mock(ResourceManager.class), mock(UserAccountManager.class), mock(ExtensionManager.class),
-      mock(VocabulariesManager.class), mock(GenerateDwcaFactory.class));
+      mock(ResourceManager.class), mock(UserAccountManager.class), mock(ExtensionManager.class), mock(GenerateDwcaFactory.class),
+            mock(VocabulariesManager.class));
     action.setResource(r);
     action.setUndelete("true");
     assertEquals("input", action.undelete());

--- a/src/test/java/org/gbif/ipt/service/manage/impl/AutoPublishedTest.java
+++ b/src/test/java/org/gbif/ipt/service/manage/impl/AutoPublishedTest.java
@@ -1,0 +1,300 @@
+package org.gbif.ipt.service.manage.impl;
+
+import org.gbif.ipt.config.AppConfig;
+import org.gbif.ipt.config.DataDir;
+import org.gbif.ipt.mock.MockAppConfig;
+import org.gbif.ipt.model.Resource;
+import org.gbif.ipt.model.converter.*;
+import org.gbif.ipt.model.voc.PublicationMode;
+import org.gbif.ipt.service.admin.ExtensionManager;
+import org.gbif.ipt.service.admin.RegistrationManager;
+import org.gbif.ipt.service.admin.VocabulariesManager;
+import org.gbif.ipt.service.manage.SourceManager;
+import org.gbif.ipt.service.registry.RegistryManager;
+import org.gbif.ipt.struts2.SimpleTextProvider;
+import org.gbif.ipt.task.Eml2Rtf;
+import org.gbif.ipt.task.GenerateDwcaFactory;
+import org.gbif.metadata.eml.MaintenanceUpdateFrequency;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
+import java.util.Locale;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+
+public class AutoPublishedTest {
+
+    private AppConfig mockAppConfig = MockAppConfig.buildMock();
+
+    private SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm", Locale.ENGLISH);
+    private Calendar calendar = Calendar.getInstance();
+
+    private ResourceManagerImpl resourceManager;
+
+    @Before
+    public void setup() {
+        resourceManager = getResourceManagerImpl();
+    }
+
+    public ResourceManagerImpl getResourceManagerImpl() {
+        return new ResourceManagerImpl(
+                mockAppConfig,
+                mock(DataDir.class),
+                mock(UserEmailConverter.class),
+                mock(OrganisationKeyConverter.class),
+                mock(ExtensionRowTypeConverter.class),
+                mock(JdbcInfoConverter.class),
+                mock(SourceManager.class),
+                mock(ExtensionManager.class),
+                mock(RegistryManager.class),
+                mock(ConceptTermConverter.class),
+                mock(GenerateDwcaFactory.class),
+                mock(PasswordConverter.class),
+                mock(Eml2Rtf.class),
+                mock(VocabulariesManager.class),
+                mock(SimpleTextProvider.class),
+                mock(RegistrationManager.class));
+    }
+
+    public Resource getResource() {
+        Resource r = new Resource();
+        r.setPublicationMode(PublicationMode.AUTO_PUBLISH_ON);
+        return r;
+    }
+
+    @Test
+    public void testAnnuallyFrequency()
+            throws ParseException {
+        Resource resource = getResource();
+
+       resource.setAutoPublishingFrequency(MaintenanceUpdateFrequency.ANNUALLY.getIdentifier(),
+                "july",
+                "",
+                14, // 14th
+                "",
+                15,
+                8);
+
+        // Current date is before July ==> July, same year
+        resourceManager.updateNextPublishedDate(formatter.parse("2001-04-21T14:08"), resource);
+        assertEquals(formatter.format(resource.getNextPublished()), "2001-07-14T15:08");
+
+        // Current date is after July ==> July, mext year
+        resourceManager.updateNextPublishedDate(formatter.parse("2001-11-21T14:08"), resource);
+        assertEquals(formatter.format(resource.getNextPublished()), "2002-07-14T15:08");
+    }
+
+    @Test
+    public void testFebruaryAnnuallyFrequency()
+            throws ParseException {
+        Resource resource = getResource();
+
+        resource.setAutoPublishingFrequency(MaintenanceUpdateFrequency.ANNUALLY.getIdentifier(),
+                "february",
+                "",
+                31, // 31th
+                "",
+                15,
+                8);
+
+        // "31st of February" = 3rd of March
+        resourceManager.updateNextPublishedDate(formatter.parse("2001-01-21T14:08"), resource);
+        assertEquals(formatter.format(resource.getNextPublished()), "2001-03-03T15:08");
+    }
+
+    @Test
+    public void testBiAnnuallyFrequency()
+            throws ParseException {
+        Resource resource = getResource();
+
+        resource.setAutoPublishingFrequency(MaintenanceUpdateFrequency.BIANNUALLY.getIdentifier(),
+                "",
+                "march_september",
+                14, // 14th
+                "",
+                15,
+                8);
+
+        // Current date is before the first month (March) ==> March
+        resourceManager.updateNextPublishedDate(formatter.parse("2001-01-21T14:08"), resource);
+        assertEquals(formatter.format(resource.getNextPublished()), "2001-03-14T15:08");
+
+        // Current date is between the 2 months (March and September) ==> September
+        resourceManager.updateNextPublishedDate(formatter.parse("2001-05-21T14:08"), resource);
+        assertEquals(formatter.format(resource.getNextPublished()), "2001-09-14T15:08");
+
+        // Current date is after the second month (September) ==> March, next year
+        resourceManager.updateNextPublishedDate(formatter.parse("2001-11-21T14:08"), resource);
+        assertEquals(formatter.format(resource.getNextPublished()), "2002-03-14T15:08");
+    }
+
+    @Test
+    public void testMonthlyFrequency()
+            throws ParseException {
+        Resource resource = getResource();
+
+        resource.setAutoPublishingFrequency(MaintenanceUpdateFrequency.MONTHLY.getIdentifier(),
+                "",
+                "",
+                14, // 14th
+                "",
+                15,
+                8);
+
+        // Current date is before 14th ==> same month
+        resourceManager.updateNextPublishedDate(formatter.parse("2001-04-05T14:08"), resource);
+        assertEquals(formatter.format(resource.getNextPublished()), "2001-04-14T15:08");
+
+        // Current date is after 14th ==> next month
+        resourceManager.updateNextPublishedDate(formatter.parse("2001-04-21T14:08"), resource);
+        assertEquals(formatter.format(resource.getNextPublished()), "2001-05-14T15:08");
+
+        // Current date is equal 14th, just after ==> next month
+        resourceManager.updateNextPublishedDate(formatter.parse("2001-04-14T16:08"), resource);
+        assertEquals(formatter.format(resource.getNextPublished()), "2001-05-14T15:08");
+
+        // Current date is equal 14th, just before ==> same day
+        resourceManager.updateNextPublishedDate(formatter.parse("2001-04-14T14:08"), resource);
+        assertEquals(formatter.format(resource.getNextPublished()), "2001-04-14T15:08");
+    }
+
+    @Test
+    public void testFebruaryMonthlyFrequency()
+            throws ParseException {
+        Resource resource = getResource();
+
+        resource.setAutoPublishingFrequency(MaintenanceUpdateFrequency.MONTHLY.getIdentifier(),
+                "",
+                "",
+                31, // 31th
+                "",
+                15,
+                8);
+
+        // Current date is February ==> March ("31st of February")
+        resourceManager.updateNextPublishedDate(formatter.parse("2001-02-05T14:08"), resource);
+        assertEquals(formatter.format(resource.getNextPublished()), "2001-03-03T15:08");
+    }
+
+    @Test
+    public void testWeeklyFrequency()
+            throws ParseException {
+        Resource resource = getResource();
+
+        resource.setAutoPublishingFrequency(MaintenanceUpdateFrequency.WEEKLY.getIdentifier(),
+                "",
+                "",
+                0,
+                "wednesday",
+                15,
+                8);
+
+        // 2001-04-01: Sunday
+        // 2001-04-04: Wednesday
+        resourceManager.updateNextPublishedDate(formatter.parse("2001-04-01T14:08"), resource);
+        assertEquals(formatter.format(resource.getNextPublished()), "2001-04-04T15:08");
+
+        // 2001-04-04: Wednesday
+        // 2001-04-04: Wednesday
+        resourceManager.updateNextPublishedDate(formatter.parse("2001-04-04T14:08"), resource);
+        assertEquals(formatter.format(resource.getNextPublished()), "2001-04-04T15:08");
+
+        // 2001-04-06: Friday
+        // 2001-04-06: Wednesday
+        resourceManager.updateNextPublishedDate(formatter.parse("2001-04-06T16:08"), resource);
+        assertEquals(formatter.format(resource.getNextPublished()), "2001-04-11T15:08");
+
+        // 2001-04-30: Monday
+        // 2001-05-02: Wednesday
+        resourceManager.updateNextPublishedDate(formatter.parse("2001-04-30T14:08"), resource);
+        assertEquals(formatter.format(resource.getNextPublished()), "2001-05-02T15:08");
+    }
+
+    @Test
+    public void testDailyFrequency()
+            throws ParseException {
+        Resource resource = getResource();
+
+        resource.setAutoPublishingFrequency(MaintenanceUpdateFrequency.DAILY.getIdentifier(),
+                "",
+                "",
+                0,
+                "",
+                15,
+                8);
+
+        // Current date is before ==> same day
+        resourceManager.updateNextPublishedDate(formatter.parse("2001-04-21T14:08"), resource);
+        assertEquals(formatter.format(resource.getNextPublished()), "2001-04-21T15:08");
+
+        // Current date is after ==> next day
+        resourceManager.updateNextPublishedDate(formatter.parse("2001-04-21T16:08"), resource);
+        assertEquals(formatter.format(resource.getNextPublished()), "2001-04-22T15:08");
+
+        // Current date is last day of month ==> next month
+        resourceManager.updateNextPublishedDate(formatter.parse("2001-04-30T16:08"), resource);
+        assertEquals(formatter.format(resource.getNextPublished()), "2001-05-01T15:08");
+    }
+
+    @Test
+    public void testBackwardCompatibilityAnnuallyFrequency()
+            throws ParseException {
+        Resource resource = getResource();
+
+        resource.setUpdateFrequency(MaintenanceUpdateFrequency.ANNUALLY.getIdentifier());
+
+        resourceManager.updateNextPublishedDate(formatter.parse("2001-04-21T14:08"), resource);
+        assertEquals(formatter.format(resource.getNextPublished()), "2002-04-21T14:08");
+    }
+
+    @Test
+    public void testBackwardCompatibilityBiAnnuallyFrequency()
+            throws ParseException {
+        Resource resource = getResource();
+
+        resource.setUpdateFrequency(MaintenanceUpdateFrequency.BIANNUALLY.getIdentifier());
+
+        resourceManager.updateNextPublishedDate(formatter.parse("2001-01-21T14:08"), resource);
+        assertEquals(formatter.format(resource.getNextPublished()), "2001-07-22T14:08");
+
+        resourceManager.updateNextPublishedDate(formatter.parse("2001-11-21T14:08"), resource);
+        assertEquals(formatter.format(resource.getNextPublished()), "2002-05-22T14:08");
+    }
+
+    @Test
+    public void testBackwardCompatibilityMonthlyFrequency()
+            throws ParseException {
+        Resource resource = getResource();
+
+        resource.setUpdateFrequency(MaintenanceUpdateFrequency.MONTHLY.getIdentifier());
+
+        resourceManager.updateNextPublishedDate(formatter.parse("2001-04-05T14:08"), resource);
+        assertEquals(formatter.format(resource.getNextPublished()), "2001-05-05T14:08");
+    }
+
+    @Test
+    public void testBackwardCompatibilityWeeklyFrequency()
+            throws ParseException {
+        Resource resource = getResource();
+
+        resource.setUpdateFrequency(MaintenanceUpdateFrequency.WEEKLY.getIdentifier());
+
+        resourceManager.updateNextPublishedDate(formatter.parse("2001-04-01T14:08"), resource);
+        assertEquals(formatter.format(resource.getNextPublished()), "2001-04-08T14:08");
+    }
+
+    @Test
+    public void testBackwardCompatibilityDailyFrequency()
+            throws ParseException {
+        Resource resource = getResource();
+
+        resource.setUpdateFrequency(MaintenanceUpdateFrequency.DAILY.getIdentifier());
+
+        resourceManager.updateNextPublishedDate(formatter.parse("2001-04-21T14:08"), resource);
+        assertEquals(formatter.format(resource.getNextPublished()), "2001-04-22T14:08");
+    }
+}


### PR DESCRIPTION
Implementation of both (too much overlap - cannot be done separately):

1506 Add options in auto-publish to define the next published date more precisely
1505 Cannot change auto-publish settings or turn it off without publishing a version

![ipt_1505_1506](https://user-images.githubusercontent.com/56630013/96754373-811a2900-13d1-11eb-91ea-a06187ab6314.gif)

For backward compatiblity, the old "next publication date" algorithm is still used.
A warning message is displayed to ask the user to review its configuration (this will migrate the auto-publish configuration to the new version)

![ipt_1505_1506_compatibility](https://user-images.githubusercontent.com/56630013/96754511-aeff6d80-13d1-11eb-8af0-db2ca1fd63b2.gif)
