### PR TITLE
1511 report filesystem error

### DIFF
--- a/src/main/java/org/gbif/ipt/config/ConfigManagerImpl.java
+++ b/src/main/java/org/gbif/ipt/config/ConfigManagerImpl.java
@@ -236,18 +236,19 @@ public class ConfigManagerImpl extends BaseManager implements ConfigManager {
       LOG.error("Resources directory cannot be written. Please check access rights for: " + resourcesDir);
       warnings.addStartupError("Resources directory cannot be written. Please check access rights for: " + resourcesDir);
     }
-    // READ/WRITE access of sub folders of  of /resources
+    // READ/WRITE access of sub folders of /resources
     else {
       File[] files = resourcesDir.listFiles();
       if (files != null) {
         for (File subResourceDir : files) {
           if (subResourceDir != null && subResourceDir.exists()) {
+            // READ access of sub folders of /resources
             if (!subResourceDir.canRead()) {
               LOG.error("At least one resource directory cannot be read. Please check access rights for: " + subResourceDir);
               warnings.addStartupError("At least one resource directory cannot be read. Please check access rights for: " + subResourceDir);
               break;
             }
-            // WRITE access of /resources
+            // WRITE access of sub folders of /resources
             else if (!subResourceDir.canWrite()) {
               LOG.error("At least one resource directory cannot be written. Please check access rights for: " + subResourceDir);
               warnings.addStartupError("At least one resource directory cannot be written. Please check access rights for: " + subResourceDir);

--- a/src/main/java/org/gbif/ipt/config/ConfigManagerImpl.java
+++ b/src/main/java/org/gbif/ipt/config/ConfigManagerImpl.java
@@ -221,39 +221,41 @@ public class ConfigManagerImpl extends BaseManager implements ConfigManager {
   }
 
   private void checkResourcesDirAtStartup(File resourcesDir) {
+    // No folder /resources
+    if (resourcesDir == null || !resourcesDir.exists()) {
+      LOG.error("Resources directory does not exist: " + resourcesDir);
+      warnings.addStartupError("Resources directory does not exist: " + resourcesDir);
+    }
     // READ access of /resources
-    if (resourcesDir != null && resourcesDir.exists() && !resourcesDir.canRead()) {
+    else if (!resourcesDir.canRead()) {
       LOG.error("Resources directory cannot be read. Please check access rights for: " + resourcesDir);
       warnings.addStartupError("Resources directory cannot be read. Please check access rights for: " + resourcesDir);
     }
     // WRITE access of /resources
-    else if (resourcesDir != null && resourcesDir.exists() && !resourcesDir.canWrite()) {
+    else if (!resourcesDir.canWrite()) {
       LOG.error("Resources directory cannot be written. Please check access rights for: " + resourcesDir);
       warnings.addStartupError("Resources directory cannot be written. Please check access rights for: " + resourcesDir);
     }
     // READ/WRITE access of sub folders of  of /resources
-    else if (resourcesDir != null && resourcesDir.exists()) {
+    else {
       File[] files = resourcesDir.listFiles();
       if (files != null) {
-        for (File resourceDir : files) {
-          if (resourceDir != null && resourceDir.exists() && !resourceDir.canRead()) {
-            LOG.error("At least one resource directory cannot be read. Please check access rights for: " + resourceDir);
-            warnings.addStartupError("At least one resource directory cannot be read. Please check access rights for: " + resourceDir);
-            break;
-          }
-          // WRITE access of /resources
-          else if (resourceDir != null && resourceDir.exists() && !resourceDir.canWrite()) {
-            LOG.error("At least one resource directory cannot be written. Please check access rights for: " + resourceDir);
-            warnings.addStartupError("At least one resource directory cannot be written. Please check access rights for: " + resourceDir);
-            break;
+        for (File subResourceDir : files) {
+          if (subResourceDir != null && subResourceDir.exists()) {
+            if (!subResourceDir.canRead()) {
+              LOG.error("At least one resource directory cannot be read. Please check access rights for: " + subResourceDir);
+              warnings.addStartupError("At least one resource directory cannot be read. Please check access rights for: " + subResourceDir);
+              break;
+            }
+            // WRITE access of /resources
+            else if (!subResourceDir.canWrite()) {
+              LOG.error("At least one resource directory cannot be written. Please check access rights for: " + subResourceDir);
+              warnings.addStartupError("At least one resource directory cannot be written. Please check access rights for: " + subResourceDir);
+              break;
+            }
           }
         }
       }
-    }
-    // No folder /resources
-    else {
-      LOG.error("Resources directory does not exist: " + resourcesDir);
-      warnings.addStartupError("Resources directory does not exist: " + resourcesDir);
     }
   }
 

--- a/src/main/java/org/gbif/ipt/service/manage/impl/ResourceManagerImpl.java
+++ b/src/main/java/org/gbif/ipt/service/manage/impl/ResourceManagerImpl.java
@@ -986,7 +986,7 @@ public class ResourceManagerImpl extends BaseManager implements ResourceManager,
       LOG.info("Loaded " + counter + " resources into memory altogether.");
       LOG.info("Cleaned up " + counterDeleted + " resources altogether.");
     } else {
-      LOG.info("Data directory does not hold a resources directory: " + dataDir.dataFile(""));
+      LOG.error("Data directory does not hold a resources directory: " + dataDir.dataFile(""));
     }
     return counter;
   }


### PR DESCRIPTION
Improve error reporting about the resources directory access rights.

At startup, checking:
- if the resources directory exists
- if the resources directory has read and write rights
- if all sub folders of the resources directory has read and write rights

Raising an error at startup + error in log file