### PR TITLE
Updated Oracle JDBC driver, was only suitable for pre-v11 Oracle before

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,13 @@ target/
 .classpath
 .project
 .settings/org.eclipse.jdt.core.prefs
+
+# Debug Run files #
+*.log
+eml-*.xml
+eml.xml
+rtf-*.rtf
+amphibians/
+event/
+res1/
+resource.xml

--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
     <log4j.version>2.13.3</log4j.version>
     <mockito-all.version>1.10.19</mockito-all.version>
     <mysql-connector-java.version>8.0.16</mysql-connector-java.version>
-    <ojdbc.version>14</ojdbc.version>
+    <ojdbc.version>19.9.0.0</ojdbc.version>
     <owasp-java-html-sanitizer.version>20170515.1</owasp-java-html-sanitizer.version>
     <postgresql.version>42.1.4</postgresql.version>
     <servlet-api.version>3.0.1</servlet-api.version>
@@ -468,8 +468,8 @@
       <scope>runtime</scope>
     </dependency>
     <dependency>
-      <groupId>ojdbc</groupId>
-      <artifactId>ojdbc</artifactId>
+      <groupId>com.oracle.database.jdbc</groupId>
+      <artifactId>ojdbc8</artifactId>
       <version>${ojdbc.version}</version>
       <scope>runtime</scope>
     </dependency>


### PR DESCRIPTION
Hello

We were unable to integrate IPT with Oracle v12 (soon to be v19, but it's not as big a jump as it sounds as 19 is the next version on, they've changed to yearly major version numbers, weirdly) due to the age (>10 years) of the bundled driver: ojdbc-14.jar, which predates Oracle 11g ([see compatibility matrix](https://www.oracle.com/uk/database/technologies/faq-jdbc.html))

I've updated this which will certainly provide compatibility with v12 and v19. I suspect it might be backwards compatible with v11 but that information was not immediately obvious from the compatibility matrix (and we don't have the ability to test that at the moment.)

This is tested on CentOSv7 with JDK8 (OpenJDK).

Appreciate this is a bit of a raw request, so feel free to point out anything that needs sorting. 

I also noted some build errors which had to be bypassed, but I'm happy to look at the root cause if you don't mind me lumping those into this PR. 

```
Failed tests: 
  MetadataActionTest.testDirectoriesProperties:106 expected:<4> but was:<5>
  MetadataActionTest.testLoadDirectoriesMap:112 expected:<5> but was:<6>

Tests run: 9, Failures: 2, Errors: 0, Skipped: 0, Time elapsed: 0.915 sec <<< FAILURE! - in org.gbif.ipt.action.manage.MetadataActionTest
testLoadDirectoriesMap(org.gbif.ipt.action.manage.MetadataActionTest)  Time elapsed: 0.004 sec  <<< FAILURE!
java.lang.AssertionError: expected:<5> but was:<6>
	at org.junit.Assert.fail(Assert.java:88)
	at org.junit.Assert.failNotEquals(Assert.java:834)
	at org.junit.Assert.assertEquals(Assert.java:645)
	at org.junit.Assert.assertEquals(Assert.java:631)
	at org.gbif.ipt.action.manage.MetadataActionTest.testLoadDirectoriesMap(MetadataActionTest.java:112)

testDirectoriesProperties(org.gbif.ipt.action.manage.MetadataActionTest)  Time elapsed: 0 sec  <<< FAILURE!
java.lang.AssertionError: expected:<4> but was:<5>
	at org.junit.Assert.fail(Assert.java:88)
	at org.junit.Assert.failNotEquals(Assert.java:834)
	at org.junit.Assert.assertEquals(Assert.java:645)
	at org.junit.Assert.assertEquals(Assert.java:631)
	at org.gbif.ipt.action.manage.MetadataActionTest.testDirectoriesProperties(MetadataActionTest.java:106)
```