### PR TITLE
Make Test mode images part of navbar-brand

### DIFF
--- a/src/main/webapp/WEB-INF/pages/inc/menu.ftl
+++ b/src/main/webapp/WEB-INF/pages/inc/menu.ftl
@@ -31,6 +31,10 @@
         <div class="container">
             <a href="${baseURL}/" rel="home" title="GBIF Logo" class="navbar-brand" >
                 <img src="${baseURL}/images/gbif-logo-L.svg" alt="GBIF IPT" class="gbif-logo"/>
+                [#if !cfg.devMode() && cfg.getRegistryType()?has_content && cfg.getRegistryType()=='PRODUCTION']
+                [#else]
+                    <img class="testmode" src="${baseURL}/images/testmode.png" style="width: 100px;"/>
+                [/#if]
             </a>
             <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarCollapse" aria-controls="navbarCollapse" aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"></span>
@@ -54,10 +58,6 @@
                     <li class="nav-item">
                         <a class="nav-link [#if currentMenu=='about']active[/#if]" href="${baseURL}/about.do">[@s.text name="menu.about"/]</a>
                     </li>
-                    [#if !cfg.devMode() && cfg.getRegistryType()?has_content && cfg.getRegistryType()=='PRODUCTION']
-                    [#else]
-                        <img class="testmode" src="${baseURL}/images/testmode.png" style="width: 100px;"/>
-                    [/#if]
                 </ul>
 
                 <div class="d-xl-flex align-content-between">


### PR DESCRIPTION
The test mode image is currently part of the menu (which looks odd on small screens):

<img width="1024" alt="Screenshot 2021-06-02 at 16 09 50" src="https://user-images.githubusercontent.com/600993/120495481-09779800-c3bd-11eb-9552-546d20238477.png">

This PR makes it part of the `navbar-brand`, so it doesn't get collapsed in the menu:

<img width="980" alt="Screenshot 2021-06-02 at 16 09 40" src="https://user-images.githubusercontent.com/600993/120495500-0e3c4c00-c3bd-11eb-9b2c-a54cf1028a7b.png">
