### PR TITLE
Take into account base URL on login redirect

### DIFF
--- a/src/main/java/org/gbif/ipt/action/LoginAction.java
+++ b/src/main/java/org/gbif/ipt/action/LoginAction.java
@@ -83,7 +83,7 @@ public class LoginAction extends POSTAction {
   }
 
   private void setRedirectUrl() {
-    redirectUrl = "/";
+    redirectUrl = getBase() + "/";
     // if we have a request refer back to the originally requested page
     if (req != null) {
       String referer = req.getHeader("Referer");


### PR DESCRIPTION
We encountered an issue with the IPT hosted at https://members.devel.oceantrack.org/ipt where logging in would redirect to the root of the domain instead of to the base URL. This PR fixes that issue, but please review as I'm a bit suprised that this issue hasn't been reported before.