### PR TITLE
Build IPT within Docker

### DIFF
--- a/package/docker/Dockerfile
+++ b/package/docker/Dockerfile
@@ -1,17 +1,19 @@
+FROM maven:3.8-jdk-8 AS builder
+
+WORKDIR /usr/src/ipt
+COPY pom.xml .
+COPY src src
+RUN mvn -DskipTests install && \
+    rm target/*.war && mv target/ipt-* target/ipt
+
 FROM tomcat:8.5-jdk8
 LABEL MAINTAINERS="Matthew Blissett <mblissett@gbif.org>"
 
-ARG IPT_VERSION
 ARG IPT_NAME=ROOT
 
 ENV IPT_DATA_DIR=/srv/ipt
 
-RUN rm -Rf /usr/local/tomcat/webapps \
-    && mkdir -p /usr/local/tomcat/webapps/${IPT_NAME} \
-    && mkdir -p ${IPT_DATA_DIR} \
-    && curl -LSsfo ipt.war https://repository.gbif.org/repository/releases/org/gbif/ipt/${IPT_VERSION}/ipt-${IPT_VERSION}.war \
-    && unzip -d /usr/local/tomcat/webapps/${IPT_NAME} ipt.war \
-    && rm -f ipt.war
+COPY --from=builder /usr/src/ipt/target/ipt /usr/local/tomcat/webapps/${IPT_NAME}
 
 VOLUME /srv/ipt
 


### PR DESCRIPTION
Fix #1706.
Documentation should be updated too.
`pom.xml` could be improved, so we could download dependencies first, and then build IPT, which would allow caching and faster build time/less space used.