### PR TITLE
Typo in EML standard "UNKOWN" instead of "UNKNOWN" for update frequency.

### DIFF
--- a/src/test/resources/thesauri/update_frequency.xml
+++ b/src/test/resources/thesauri/update_frequency.xml
@@ -124,7 +124,7 @@
     <alternative>
     </alternative>
   </concept>
-  <concept dc:identifier="unkown" dc:URI="http://rs.gbif.org/vocabulary/eml/updateFrequency/unkown"
+  <concept dc:identifier="unknown" dc:URI="http://rs.gbif.org/vocabulary/eml/updateFrequency/unknown"
            dc:relation=""
            dc:description="Further updates may still happen, but it is not known for sure.">
     <preferred>


### PR DESCRIPTION
First https://rs.gbif.org/vocabulary/eml/update_frequency.xml should be fixed.
This typo appears also in other xml files in this repository.