### PR TITLE
Fix for Dockerfile smell DL3048

### DIFF
--- a/package/docker/Dockerfile
+++ b/package/docker/Dockerfile
@@ -15,7 +15,7 @@ RUN perl -pi -e 's(\${buildNumber})('${GIT_REVISION}')' src/main/resources/appli
     rm target/*.war && mv target/ipt-* target/ipt
 
 FROM tomcat:8.5-jdk8
-LABEL MAINTAINERS="Matthew Blissett <mblissett@gbif.org>"
+LABEL maintainers="Matthew Blissett <mblissett@gbif.org>"
 
 ARG IPT_NAME=ROOT
 


### PR DESCRIPTION
Hi!
The Dockerfile placed at "package/docker/Dockerfile" contains the best practice violation [DL3048](https://github.com/hadolint/hadolint/wiki/DL3048) detected by the [hadolint](https://github.com/hadolint/hadolint) tool.

The smell DL3048 occurs when the pattern used for the label keys does not match the format recommended by official guidelines.
In this pull request, we propose a fix for that smell generated by our fixing tool. We manually checked that the patch is correct before opening the pull request.
To fix this smell, specifically, the label keys are refactored to match the correct format.

This change is only aimed at fixing that specific smell. In the case the fix is not valid or useful, please briefly indicate the reason along with suggestions for possible improvements.

Thanks in advance.