### PR TITLE
OBIS URL fixes

### DIFF
--- a/docs/en/modules/ROOT/pages/data-hosting-centres.adoc
+++ b/docs/en/modules/ROOT/pages/data-hosting-centres.adoc
@@ -79,7 +79,7 @@ The Research Institute for Nature and Forest (INBO) also provides http://data.in
 * http://www.natuurpunt.be[Natuurpunt]
 * http://www.vmm.be[Flemish Environment Agency VMM]
 
-The Flanders Marine Institute (VLIZ) is hosting a server with multiple IPT installations for http://www.vliz.be[VLIZ], http://www.iobis.org[OBIS] & http://www.emodnet-biology.eu[EMODnet Biology] at http://ipt.vliz.be. Publishers of marine data should refer to the section <<Marine data>>.
+The Flanders Marine Institute (VLIZ) is hosting a server with multiple IPT installations for http://www.vliz.be[VLIZ], https://obis.org[OBIS] & http://www.emodnet-biology.eu[EMODnet Biology] at http://ipt.vliz.be. Publishers of marine data should refer to the section <<Marine data>>.
 
 == Canada
 
@@ -169,7 +169,7 @@ http://data.freshwaterbiodiversity.eu/ipt/[Biofresh] provides data hosting and h
 
 == Marine data
 
-http://www.iobis.org[OBIS] provides data hosting and helpdesk support to publishers of marine data around the globe. EurOBIS/Flanders Marine Institute (VLIZ) hosts multiple IPT installations discoverable at http://ipt.vliz.be/ on behalf of various OBIS Nodes. Currently, there are more than http://www.iobis.org/about/[20 OBIS Nodes] around the world connecting 500 institutions from 56 countries.
+https://obis.org[OBIS] provides data hosting and helpdesk support to publishers of marine data around the globe. EurOBIS/Flanders Marine Institute (VLIZ) hosts multiple IPT installations discoverable at http://ipt.vliz.be/ on behalf of various OBIS Nodes. Currently, there are more than 30 OBIS Nodes around the world connecting 2000 institutions from 86 countries.
 
 == Vertebrate data
 


### PR DESCRIPTION
This fixes outdated OBIS URLs in the IPT manual.