### PR TITLE
Support compressed URL source

### DIFF
--- a/src/main/java/org/gbif/ipt/action/manage/SourceAction.java
+++ b/src/main/java/org/gbif/ipt/action/manage/SourceAction.java
@@ -153,7 +153,7 @@ public class SourceAction extends ManagerBaseAction {
 
         // check text file (or no extension)
         String extension = FilenameUtils.getExtension(url);
-        if (!extension.isEmpty() && !"txt".equals(extension) && !"tsv".equals(extension) && !"csv".equals(extension)) {
+        if (!extension.isEmpty() && !"txt".equals(extension) && !"tsv".equals(extension) && !"csv".equals(extension) && !"zip".equals(extension)) {
           addActionError(getText("manage.source.url.invalidExtension", new String[] {url, extension}));
           removeSessionData();
           return ERROR;

--- a/src/main/java/org/gbif/ipt/service/manage/impl/SourceManagerImpl.java
+++ b/src/main/java/org/gbif/ipt/service/manage/impl/SourceManagerImpl.java
@@ -429,7 +429,11 @@ public class SourceManagerImpl extends BaseManager implements SourceManager {
     File file = new File(dataDir.tmpDir(), filename);
 
     try (InputStream in = url.toURL().openStream()) {
-      Files.copy(in, file.toPath(), StandardCopyOption.REPLACE_EXISTING);
+      if (url.toString().endsWith("zip")) {
+        Files.copy(UrlSource.decompressInputStream(in), file.toPath(), StandardCopyOption.REPLACE_EXISTING);
+      } else {
+        Files.copy(in, file.toPath(), StandardCopyOption.REPLACE_EXISTING);
+      }
       src.setFile(file);
       // analyze individual files using the dwca reader
       Archive arch = DwcFiles.fromLocation(file.toPath());


### PR DESCRIPTION
This is a basic implementation of handling compressed text files as URL sources, see https://github.com/gbif/ipt/issues/1632. In case of a URL source with file extension `zip`, the first file within the archive will be extracted and treated as a text file.