### PR TITLE
Adding a fix for the problem of eml truncation https://github.com/gbif/ipt/issues/2061

### DIFF
--- a/package/docker/Dockerfile
+++ b/package/docker/Dockerfile
@@ -23,6 +23,9 @@ ENV IPT_DATA_DIR=/srv/ipt
 
 COPY --from=builder /usr/src/ipt/target/ipt /usr/local/tomcat/webapps/${IPT_NAME}
 
+# Modify maxParameterCount in server.xml
+RUN sed -i 's/maxParameterCount="1000"/maxParameterCount="10000"/g' /usr/local/tomcat/conf/server.xml
+
 VOLUME /srv/ipt
 
 EXPOSE 8080


### PR DESCRIPTION
@mike-podolskiy90, @MichalTorma  and I have discovered an issue where we encounter a limit in Tomcat on URL encoded parameters (set by maxParameterCount), which prevents proper functioning of the IPT when you save metadata. More info in https://github.com/gbif/ipt/issues/2061 

If the IPT UI sends a lot of EML fields in a request (in our case 69+ authors), the IPT server side only gets the first 1000. So we've fixed it in our build like this: https://github.com/gbif-norway/ipt-s3/pull/26/commits/7e729d813576cba810eab18352f369fcec5bafe2 

@MichalTorma and I think this should probably be in your Dockerfile so that others don't encounter this problem as well.