### PR TITLE
FIX: Update docker hub image with latest tomcat version #1529

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: "docker"
+    directory: "/package/docker"
+    schedule:
+      interval: "weekly"
+##      beside Docker dependencies it is also worth to check updates for GithubActions - this second block is optional to enable also. But at this moment, GA use no dependencies.
+#  - package-ecosystem: "github-actions"
+#    directory: "/"
+#    schedule:
+#      interval: "monthly"
+#    groups:
+#      GitHubActions-dependencies:
+#        patterns:
+#          - "*"

--- a/package/docker/Dockerfile
+++ b/package/docker/Dockerfile
@@ -14,7 +14,7 @@ RUN perl -pi -e 's(\${buildNumber})('${GIT_REVISION}')' src/main/resources/appli
     mvn -DskipTests install && \
     rm target/*.war && mv target/ipt-* target/ipt
 
-FROM tomcat:9.0-jdk17
+FROM tomcat:9.0-jdk17@sha256:c7f5e6a8c40fdba9804f3c49bded2d2750c01d36380ecad872fb54c8182b544b
 LABEL maintainers="Matthew Blissett <mblissett@gbif.org>"
 
 ARG IPT_NAME=ROOT


### PR DESCRIPTION
Fix #1529 by enable Dependabot to check new versions of base Docker image by Dependabot. If new found, creates PR. To enable, the presence of dependabot.yml file should be enough, [more configuration](https://docs.github.com/en/code-security/getting-started/dependabot-quickstart-guide#enabling-dependabot-for-your-repository) about alerts etc can be found in repository settings.

