### PR TITLE
Unreadable navbar in test mode

### DIFF
--- a/src/main/webapp/styles/main.css
+++ b/src/main/webapp/styles/main.css
@@ -425,7 +425,6 @@ table {
 
 .bg-gbif-main-navbar {
     background-image: linear-gradient(to bottom, rgba(var(--navbar-color), 1), rgba(var(--navbar-color), 0.85));
-    );
 }
 
 .bg-gbif-main-navbar-test {


### PR DESCRIPTION
CSS syntax error makes the navbar unreadable (white text on white background) in text mode.
Regression in IPT 3.3.0 due to 894437aa56f7c47cceab7baa15e33b5a96668bdf.