### PR TITLE
Add ROR to user ID directory options

### DIFF
--- a/src/main/resources/org/gbif/metadata/eml/UserDirectories.properties
+++ b/src/main/resources/org/gbif/metadata/eml/UserDirectories.properties
@@ -8,3 +8,4 @@ http\://www.researcherid.com/rid/=http://www.researcherid.com/rid/
 http\://scholar.google.com/citations?user\==http://scholar.google.com/citations?user=
 https\://www.linkedin.com/profile/view?id\==https://www.linkedin.com/profile/view?id=
 http\://www.wikidata.org/entity/=http\://www.wikidata.org/entity/
+https\://ror.org/=https://ror.org/


### PR DESCRIPTION
Adds ROR (https://ror.org/) to the user ID directory dropdown for EML contacts, creators, metadata providers, and associated parties, enabling organizations to be credited with their ROR identifier.

Resolves #2373