### PR TITLE
Avoid vulnerable Oracle JDBC versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@
     <jtds.version>1.3.1</jtds.version>
     <mssql-jdbc.version>13.4.0.jre11</mssql-jdbc.version>
     <mysql-connector-java.version>9.7.0</mysql-connector-java.version>
-    <ojdbc.version>23.26.2.0.0</ojdbc.version>
+    <ojdbc.version>23.2.0.0</ojdbc.version>
     <postgresql.version>42.7.11</postgresql.version>
     <duckdb.version>1.5.2.1</duckdb.version>
 

--- a/renovate.json
+++ b/renovate.json
@@ -22,6 +22,11 @@
       "description": "Take into account mssql-jdbc compatibility suffix (jre11 currently)"
     },
     {
+      "matchPackageNames": ["com.oracle.database.jdbc:ojdbc8"],
+      "allowedVersions": "/^(?!23\\.(?:[4-9]|1\\d|2[0-6])\\.).*/",
+      "description": "Avoid Oracle JDBC 23.4.x through 23.26.x due to Oracle CSPU May 2026 TLS vulnerabilities"
+    },
+    {
       "matchPackageNames": ["com.google.guava:guava"],
       "automerge": false
     },


### PR DESCRIPTION
GBIF Norway needs to deploy this because of an Oracle Critical Security Patch Update Advisory note, just putting this in a PR in case it's of use to anyone else. 

Downgrade `com.oracle.database.jdbc:ojdbc8` from `23.26.2.0.0` to `23.2.0.0`.
Add a Renovate `allowedVersions` guard to avoid reintroducing Oracle JDBC `23.4.x` through `23.26.x`.

Oracle Critical Security Patch Update Advisory - May 2026 lists Oracle Database Server/client-only installations versions `23.4.0-23.26.2` as affected by TLS Net Service vulnerabilities, including CVE-2026-46833, CVE-2026-46834, and CVE-2026-46835.

Maven Central currently lists `23.26.2.0.0` as the latest published `ojdbc8` release, so there is no newer fixed Maven artifact to upgrade to yet. `23.2.0.0` is before the affected range.

Once Oracle publishes a fixed version above `23.26.2`, such as `23.27.x` or later, Renovate can propose that update.
