### PR TITLE
Fix logo redirect URL on logo being empty href

### DIFF
--- a/src/main/java/org/gbif/ipt/config/AppConfig.java
+++ b/src/main/java/org/gbif/ipt/config/AppConfig.java
@@ -703,7 +703,7 @@ public class AppConfig {
   }
 
   public String getLogoRedirectUrl() {
-    return properties.getProperty(LOGO_REDIRECT_URL);
+    return StringUtils.trimToNull(properties.getProperty(LOGO_REDIRECT_URL));
   }
 
   // public to be accessible by ConfigManager


### PR DESCRIPTION
Fixes getLogoRedirectURL() in BaseAction.java not falling back to default URL if the string was empty.

https://github.com/gbif/ipt/blob/b903ce00726c46d057a2144d65f2be9bd1645e5c/src/main/java/org/gbif/ipt/action/BaseAction.java#L153-L156

The logo redirect URL property could be an empty string instead of null (missing), ~~if the logo redirect URL was previously set in admin panel, and then removed again~~ (EDIT: it wasn't even needed to ever set it, to reproduce it's enough to just click Save on the IPT settings page).

This would have resulted in empty href on the logo link in HTML:

```html
<a href="" rel="home" title="Logo" class="navbar-brand">
```

...which would make the logo link redirect to the present page instead of home page.