### PR TITLE
Use HEAD request instead of GET when checking if the public URL is correct

### DIFF
--- a/src/main/webapp/WEB-INF/pages/inc/menu.ftl
+++ b/src/main/webapp/WEB-INF/pages/inc/menu.ftl
@@ -21,7 +21,7 @@
     // Check if the public URL is correct, otherwise display the fallback page
     document.addEventListener("DOMContentLoaded", function() {
         var xhr = new XMLHttpRequest();
-        xhr.open("GET", "${baseURL}/styles/main.css");
+        xhr.open("HEAD", "${baseURL}/styles/main.css");
         xhr.onload = function() {
             if (xhr.status !== 200) {
                 window.location.href = "/fallback.do";


### PR DESCRIPTION
This is a very tiny thing, but it caught my attention while looking throughout the codebase.

Using a `GET` request here is wasteful, while `HEAD` is semantically the same, but allows avoiding the transfer of the actual file's body, which we don't care about when testing just if the HTTP response is 200 OK.

I did test that it still works (and it has to work with any HTTP server that isn't completely broken).